### PR TITLE
fix: modified search boardhead components

### DIFF
--- a/src/components/Board/BoardHead.tsx
+++ b/src/components/Board/BoardHead.tsx
@@ -1,13 +1,13 @@
 interface BoardHeadProp {
   title: string;
-  subtitle: string;
+  subtitle: React.ReactNode;
 }
 
 export function BoardHead({ title, subtitle }: BoardHeadProp) {
   return (
     <div className="block">
-      <div className="mb-2 text-4xl font-bold">{title}</div>
-      <div className="text-base font-normal">{subtitle}</div>
+      <div className="mb-[11px] text-4xl font-bold">{title}</div>
+      <div className="text-base text-gray-700 font-normal">{subtitle}</div>
     </div>
   );
 }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -9,7 +9,7 @@ export function Search() {
 
   useEffect(() => {
     if (inputRef.current) {
-      if (width > 1440 || (width > 390 && width <= 720)) {
+      if (width > 1439 || (width > 390 && width <= 719)) {
         inputRef.current.placeholder = "원하시는 키워드를 입력하세요";
       } else {
         inputRef.current.placeholder = "키워드 입력";
@@ -17,24 +17,16 @@ export function Search() {
     }
   }, [width]);
 
-  // 반응형 작업은 임의로 해둔 상태 tailwind.config.js 변동사항 적용 시 수정 예정
   return (
     <div className="flex gap-2">
       <Input
         ref={inputRef}
         type="text"
-        className="w-[211px] h-[46px] border-[#959595] placeholder:text-[#B6B6B6] text-base 
-                   min-[1441px]:w-[488px] min-[1441px]:h-[58px] 
-                   min-[721px]:w-[254px] min-[721px]:h-[58px] 
-                   min-[391px]:w-[488px] min-[391px]:h-[58px]"
+        className="
+        border-[#959595] placeholder:text-[#B6B6B6] text-base  xxl:w-[488px] xxl:h-[58px] xl:w-[488px] xl:h-[58px] lg:w-[254px] lg:h-[58px] md:w-[254px] md:h-[58px] sm:w-[488px] sm:h-[58px] xs:w-[211px] xs:h-[46px]"
         placeholder="원하시는 키워드를 입력하세요"
       />
-      <Button
-        className="w-[77px] h-[46px] text-base 
-                   min-[1441px]:w-[94px] min-[1441px]:h-[58px] 
-                   min-[721px]:w-[94px] min-[721px]:h-[58px] 
-                   min-[391px]:w-[94px] min-[391px]:h-[58px]"
-      >
+      <Button className="text-base xxl:w-[94px] xxl:h-[58px] xl:w-[94px] xl:h-[58px] lg:w-[94px] lg:h-[58px] md:w-[94px] md:h-[58px] sm:w-[94px] sm:h-[58px] xs:w-[77px] xs:h-[46px]">
         검색
       </Button>
     </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ export interface InputProps
 }
 
 const InputVariants = cva(
-  "flex min-h-[58px] w-full rounded-md color-gray-800 font-semibold border bg-background px-[20px] py-[16px] text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-400 focus:outline-none focus:border focus:border-primary disabled:cursor-not-allowed disabled:opacity-50",
+  "flex min-h-[46px] w-full rounded-md color-gray-800 font-semibold border bg-background px-[20px] py-[16px] text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-gray-400 focus:outline-none focus:border focus:border-primary disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,8 @@ module.exports = {
   prefix: "",
   theme: {
     screens: {
-      sm: { max: "719px" },
+      xs: { max: "389px" },
+      sm: { min: "390px", max: "719px" },
       md: { min: "720px", max: "1079px" },
       lg: { min: "1080px", max: "1439px" },
       xl: { min: "1440px", max: "1919px" },


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #26 

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항
1. 390px 이하 화면에서 Search 컴포넌트 변경 작업이 필요해 tailwind.config.js screens 객체 수정
2. 피그마 상의 검색창 반응형 구현을 위해 input 태그의 min-heigth 속성을 h-[46px] 으로 변경
3. BoardHead subtitle 속성은 단순  string이 아니라 ReactNode 로 수정
4. Search 컴포넌트 반응형 작업 수정

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..
페이지 작업 하다보니 공통적으로 적용되어야 수정사항인거 같아 PR 올렸습니다. 수정 필요한 부분은 리뷰 남겨주세요!

## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트 

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
