### PR TITLE
feat: add layout template

### DIFF
--- a/src/template/BodyLayout.tsx
+++ b/src/template/BodyLayout.tsx
@@ -1,0 +1,38 @@
+import Pagination from '@/components/Pagination';
+import { WriteButton } from '@/components/Buttons/BoardActionButtons';
+import { Search } from '@/components/Search/Search';
+import { BodyLayoutProps } from '@/types/layout';
+
+export function BodyLayout({
+  title,
+  selector,
+  content,
+  totalPages,
+  currentPage,
+  onPageChange,
+  onWriteClick,
+}: BodyLayoutProps) {
+  return (
+    <div className="mb-20 mt-[70px] px-[200px] xs:px-10 sm:px-10 md:px-10 lg:px-10">
+      <p className="mb-6 text-[28px] font-bold">{title}</p>
+      {selector}
+      <div className="mt-11">
+        <main>{content}</main>
+        <div className="flex xs:mt-9 xs:flex-col-reverse sm:mt-9 sm:flex-col-reverse md:mt-8 md:justify-between lg:mt-8 lg:justify-between xl:mt-8 xl:justify-between xxl:mt-8 xxl:justify-between">
+          <div className="w-[94px]"></div>
+          <div className="flex justify-center xs:mt-[17px] sm:mt-[17px]">
+            <div className="lg:mt-[66px] xl:mt-[66px] xxl:mt-[66px]">
+              <Pagination totalPages={totalPages} currentPage={currentPage} onPageChange={onPageChange} />
+            </div>
+          </div>
+          <div className="flex justify-end xs:justify-center sm:justify-center">
+            <WriteButton onClick={onWriteClick} />
+          </div>
+        </div>
+      </div>
+      <div className="flex justify-center xs:mt-[17px] sm:mt-[17px] md:mt-[42px] lg:hidden xl:hidden xxl:hidden">
+        <Search />
+      </div>
+    </div>
+  );
+}

--- a/src/template/EditLayout.tsx
+++ b/src/template/EditLayout.tsx
@@ -1,0 +1,10 @@
+import { EditLayoutProps } from '@/types/layout';
+
+export function EditLayout({ children, title }: EditLayoutProps) {
+  return (
+    <div className="mb-14 mt-[150px] flex flex-col px-[200px] xs:px-[34px] sm:px-[34px] md:px-[72px]">
+      <div className="mb-[29px] whitespace-nowrap text-[34px] font-bold">{title}</div>
+      <main>{children}</main>
+    </div>
+  );
+}

--- a/src/template/HeadLayout.tsx
+++ b/src/template/HeadLayout.tsx
@@ -1,0 +1,14 @@
+import { BoardHead } from '@/components/Board/BoardHead';
+import { Search } from '@/components/Search/Search';
+import { HeadLayoutProps } from '@/types/layout';
+
+export function HeadLayout({ title, subtitle }: HeadLayoutProps) {
+  return (
+    <div className="mt-[152px] flex justify-between border-b border-b-[#E7E7E7] px-[200px] pb-9 xs:px-10 sm:px-10 md:px-10 lg:px-10">
+      <BoardHead title={title} subtitle={subtitle} />
+      <div className="xs:hidden sm:hidden md:hidden">
+        <Search />
+      </div>
+    </div>
+  );
+}

--- a/src/types/layout/index.tsx
+++ b/src/types/layout/index.tsx
@@ -1,0 +1,19 @@
+export interface HeadLayoutProps {
+  title: string;
+  subtitle: React.ReactNode;
+}
+
+export interface BodyLayoutProps {
+  title?: string;
+  selector: React.ReactNode;
+  content: React.ReactNode;
+  totalPages: number;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  onWriteClick: () => void;
+}
+
+export interface EditLayoutProps {
+  children: React.ReactNode;
+  title: string;
+}


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #43 

### 기존 코드에 영향을 미치지 않는 변경사항

template 폴더 생성 후 게시판 페이지에 공통적으로 적용되는 레이아웃 템플릿 생성(게시글 상세 페이지 레이아웃 제외)

HeadLayout.tsx -> BoardHead 컴포넌트와 Search 컴포넌트 영역의 layout
BodyLayou.tsx -> 게시판 페이지의 메인 컨텐츠 영역과 pagination 컴포넌트, 글쓰기 버튼 영역의 layout
EditLayout.tsx -> 게시글 작성 페이지의 layout

### 기존 코드에 영향을 미치는 변경사항

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..
![스크린샷 2024-08-09 16 40 50](https://github.com/user-attachments/assets/cc31b949-a934-4aac-902b-6cba38cde8e2)

![스크린샷 2024-08-09 16 40 34](https://github.com/user-attachments/assets/c1c3e55a-bdde-457d-8ff8-a341b487d26e)

`<EditLayout title="청원글 작성"> toast-ui 영역 </EditLayout>`

레이아웃 컴포넌트 사용 예제는 위와 같이 구현했습니다. 수정사항 있으시면 리뷰 달아주세용

## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
