### PR TITLE
fix: switch classname 사용처에서 적용 안됨

### DIFF
--- a/src/components/Switch/index.tsx
+++ b/src/components/Switch/index.tsx
@@ -1,13 +1,18 @@
+import { cn } from '@/libs/utils';
+
 interface SwitchProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isActive: boolean;
 }
 
-export function Switch({ isActive, children, ...props }: SwitchProps) {
+export function Switch({ isActive, children, className, ...props }: SwitchProps) {
   return (
     <button
-      className={`rounded-md px-5 py-2 text-center text-lg font-bold transition-colors duration-100 ${
-        isActive ? 'bg-primary text-white' : 'bg-white text-gray-700 hover:bg-gray-100'
-      }`}
+      className={cn(
+        `rounded-md px-5 py-2 text-center text-lg font-bold transition-colors duration-100 ${
+          isActive ? 'bg-primary text-white' : 'bg-white text-gray-700 hover:bg-gray-100'
+        }`,
+        className
+      )}
       {...props}
     >
       {children}

--- a/src/pages/router.tsx
+++ b/src/pages/router.tsx
@@ -4,7 +4,7 @@ import { BoardPage } from './boardTest/page';
 import { KakaoRegisterPage } from './kakao/page';
 import { GeneralRegisterPage } from './general/page';
 import KakaoRedirect from './kakao/containers/KakaoRedirect';
-import { IntroPage } from './Intro/page';
+import { IntroPage } from './intro/page';
 
 export function MainRouter() {
   return (


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #49 

### 기존 코드에 영향을 미치지 않는 변경사항
- `router.tsx`에서 대소문자가 잘못 입력되어있는 path 수정했습니다.

### 버그 픽스
- `cn`을 적용해서 사용해서 사용처의 classname과 기존 classname이 머지될 수 있도록 하였습니다.

## 2️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
