### PR TITLE
fix: FilterDropDown에 cn() 추가

### DIFF
--- a/src/components/FilterDropDown/FilterDropDown.tsx
+++ b/src/components/FilterDropDown/FilterDropDown.tsx
@@ -1,18 +1,19 @@
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { cn } from '@/libs/utils';
 
-interface FilterDropDownProps {
+interface FilterDropDownProps  extends React.HTMLAttributes<HTMLDivElement>  {
     defaultValue: string
     optionValue: string[]
     onValueChange: (value: string) => void
     value: string
 }
 
-export function FilterDropDown({ defaultValue, optionValue, onValueChange, value }: FilterDropDownProps) {
+export function FilterDropDown({ className, defaultValue, optionValue, onValueChange, value }: FilterDropDownProps) {
   const isSelected = !!value;
 
   return (
-    <Select onValueChange={onValueChange} value={value}>
-      <SelectTrigger className={`h-[67px] w-[411px] pl-9 ${isSelected ? 'text-gray-800' : 'text-gray-500'}`}>
+    <Select  onValueChange={onValueChange} value={value}>
+      <SelectTrigger className={cn(`h-[67px] w-[411px] pl-9 ${isSelected ? 'text-gray-800' : 'text-gray-500'}`,className)}>
         <SelectValue placeholder={defaultValue} />
       </SelectTrigger>
       <SelectContent>


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #(52)

### 기존 코드에 영향을 미치지 않는 변경사항

Components  - FilterDropDown 컴포넌트에 cn() 추가했습니다.

### 버그 픽스

cn()을 적용해서 사용처의 classname과 기존 classname이 머지될 수 있도록 하였습니다.

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
