### PR TITLE
feat: axios 인스턴스 객체 생성 및 카카오 로그인 로직 일부 수정

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,5 +1,36 @@
-import axios from 'axios';
+import axios, { AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 
+interface CustomInternalAxiosRequestConfig extends InternalAxiosRequestConfig {
+  requireAuth?: boolean;
+}
+
+// 토큰이 필요하지 않은 api 요청 시에 사용하는 함수
 export const client = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
 });
+
+// 헤더에 토큰 추가
+client.interceptors.request.use(
+  (config: CustomInternalAxiosRequestConfig) => {
+    if (config.requireAuth && localStorage.getItem('accessToken')) {
+      const accessToken = localStorage.getItem('accessToken');
+      config.headers = config.headers || {};
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 토큰이 필요한 api 요청 시에 사용하는 함수
+export const clientAuth = <T>(config: AxiosRequestConfig): Promise<AxiosResponse<T>> => {
+  return client({
+    ...config,
+    requireAuth: true,
+  } as CustomInternalAxiosRequestConfig);
+};

--- a/src/apis/kakaoLoginApi.ts
+++ b/src/apis/kakaoLoginApi.ts
@@ -2,5 +2,5 @@ import { UserType } from '@/pages/kakao/containers/types/kakaoLoginType';
 import { client } from '@/apis/client';
 
 export const kakaoAuthCodeApi = (authCode: string) => {
-  return client.get<string | UserType>(`/auth/callback?code=${authCode}`);
+  return client.get<UserType>(`/auth/callback?code=${authCode}`);
 };

--- a/src/pages/kakao/containers/KakaoRedirect.tsx
+++ b/src/pages/kakao/containers/KakaoRedirect.tsx
@@ -14,7 +14,9 @@ const KakaoRedirect = () => {
         const response = await kakaoAuthCodeApi(AUTHORIZE_CODE);
         console.log(response);
         const res = response.data;
+        const accessToken = response.data.data.accessToken;
         localStorage.setItem('kakaoData', JSON.stringify(res));
+        localStorage.setItem('accessToken', accessToken);
 
         navigate('/register/onboarding');
       } catch (err) {
@@ -25,7 +27,7 @@ const KakaoRedirect = () => {
     kakaoLogin();
   }, [AUTHORIZE_CODE, navigate]);
 
-  return <div>Loading...</div>;
+  return <div>Loading…</div>;
 };
 
 export default KakaoRedirect;


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #78 

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

카카오 로그인 로직 중 서버에서 받아온 토큰은 따로 accessToken key 로 로컬스토리지에 저장하도록 추가
axios 인터셉터 설정 및 토큰이 필요한 api 요청과 아닌 요청을 분리하기 위한 clientAuth 함수 새로 정의

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..
토큰이 필요없는 api 요청 예시
`client.get('/api_endpoint');`

토큰이 필요한 api 요청 예시
`clientAuth({
  method: 'get',
  url: '/api_endpoint'
});`


## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
