### PR TITLE
Fix/#88 register error fix

### DIFF
--- a/src/apis/postOnboardingMail.ts
+++ b/src/apis/postOnboardingMail.ts
@@ -1,0 +1,5 @@
+import { client } from '@/apis/client';
+
+export const postOnboardingMail = (resBody: object) => {
+  return client.post(`/onboarding/mail`, resBody, {});
+};

--- a/src/pages/general/containers/CertifyApplySection.tsx
+++ b/src/pages/general/containers/CertifyApplySection.tsx
@@ -40,7 +40,7 @@ export function CertifyApplySection() {
     try {
       const resBody = {
         name: formValues.name,
-        studentId: Number(formValues.id), // 학번을 제대로 넘기도록 수정
+        studentId: Number(0),
         email: formValues.email,
         content: formValues.inquiry,
       };

--- a/src/pages/general/containers/CertifyApplySection.tsx
+++ b/src/pages/general/containers/CertifyApplySection.tsx
@@ -5,6 +5,7 @@ import { useForm } from 'react-hook-form';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { LoginSchemaCertify, LoginType } from './ZodCheck';
+import { postOnboardingMail } from '@/apis/postOnboardingMail'; // Import the postOnboardingMail function
 
 export function CertifyApplySection() {
   const {
@@ -36,8 +37,33 @@ export function CertifyApplySection() {
   }, [formValues, isScouncilPath]);
 
   const onSubmit = async () => {
-    alert('문의내용이 확인되었습니다.');
-    navigate('/register/errorcheck');
+    try {
+      const resBody = {
+        name: formValues.name,
+        studentId: Number(formValues.id), // 학번을 제대로 넘기도록 수정
+        email: formValues.email,
+        content: formValues.inquiry,
+      };
+
+      console.log('Request body being sent:', resBody);
+
+      const response = await postOnboardingMail(resBody);
+      console.log('Response from server:', response);
+
+      alert('문의내용이 확인되었습니다.');
+      navigate('/register/errorcheck');
+    } catch (error) {
+      if (error.response) {
+        console.error('Server error response:', error.response.status, error.response.data);
+        alert(`서버 오류 발생: ${error.response.data.message || '문의 내용을 전송하는데 실패했습니다.'}`);
+      } else if (error.request) {
+        console.error('No response received:', error.request);
+        alert('서버로부터 응답을 받을 수 없습니다.');
+      } else {
+        console.error('Error setting up request:', error.message);
+        alert('문의 내용을 전송하는데 문제가 발생했습니다.');
+      }
+    }
   };
 
   return (

--- a/src/pages/general/containers/GeneralRegisterSection.tsx
+++ b/src/pages/general/containers/GeneralRegisterSection.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useForm } from 'react-hook-form';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { faculties, departments } from './index';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { client } from '@/apis/client';
-import { LoginSchemaRegister, LoginType } from './ZodCheck'; // 수정된 zod 스키마 경로
+import { LoginSchemaRegister, LoginType } from './ZodCheck';
 
 interface LoginFormProps {
   subSection1: string;
@@ -23,63 +23,69 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
     setValue,
   } = useForm<LoginType>({
     resolver: zodResolver(LoginSchemaRegister),
+    mode: 'onChange', // 폼 상태가 변경될 때마다 유효성 검사
   });
 
   const navigate = useNavigate();
   const location = useLocation();
 
-  const [inputUserData, setInputUserData] = useState(null);
   const [selectedFaculty, setSelectedFaculty] = useState<string>('');
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 
+  const [inputUserData, setInputUserData] = useState(null);
   const isScouncilPath = location.pathname === '/register/scouncil';
   const showSelects = !isScouncilPath;
   const formValues = watch();
+  const formValuesScouncil = watch();
+  const { sort } = useParams();
 
+  /*
   useEffect(() => {
-    const storedFormValues = localStorage.getItem('formValues');
-    setInputUserData(storedFormValues ? JSON.parse(storedFormValues) : null);
+    if (sort !== 'scouncil') {
+      const storedFormValues = localStorage.getItem('formValues');
+      setInputUserData(storedFormValues ? JSON.parse(storedFormValues) : null);
 
-    const kakaoData = localStorage.getItem('kakaoData');
-    if (kakaoData) {
-      const parsedKakaoData = JSON.parse(kakaoData);
-      if (parsedKakaoData.data?.name && parsedKakaoData.data?.studentId) {
-        navigate('/');
+      const kakaoData = localStorage.getItem('kakaoData');
+      if (kakaoData) {
+        const parsedKakaoData = JSON.parse(kakaoData);
+        if (parsedKakaoData.data?.name && parsedKakaoData.data?.studentId) {
+          navigate('/');
+        }
       }
     }
-  }, [navigate]);
-
+  }, [navigate, sort]);
+*/
   useEffect(() => {
-    localStorage.setItem('formValues', JSON.stringify(formValues));
-  }, [formValues]);
-
-  useEffect(() => {
-    localStorage.setItem('formValues', JSON.stringify(formValues));
-  }, [formValues]);
-
-  useEffect(() => {
-    setSelectedFaculty(formValues.memberCode || '');
-    if (!formValues.memberCode) {
-      setValue('majorCode', '');
+    if (!isScouncilPath) {
+      localStorage.setItem('formValues', JSON.stringify(formValues));
+    } else {
+      localStorage.setItem('formValuesScouncil', JSON.stringify(formValuesScouncil));
     }
-  }, [formValues.memberCode]);
+  }, [formValues, formValuesScouncil, isScouncilPath]);
 
   useEffect(() => {
-    const isFormValid = isScouncilPath
-      ? formValues.studentId && formValues.password
-      : formValues.name && formValues.studentId && formValues.memberCode && formValues.majorCode;
+    // 폼 유효성 검사 추가
+    const isFormValid = Object.keys(errors).length === 0 && Object.values(formValues).every(Boolean);
     setIsButtonDisabled(!isFormValid);
-  }, [formValues, isScouncilPath]);
+  }, [errors, formValues]); // 필드 값이 변경될 때마다 재검사
 
   const onSubmit = async () => {
+    if (isButtonDisabled) {
+      alert('폼에 오류가 있습니다. 입력 내용을 확인해 주세요.');
+      return;
+    }
+
+    const targetFormValues = isScouncilPath ? formValuesScouncil : formValues;
+
     try {
       const UserData = localStorage.getItem('kakaoData');
-
       if (UserData) {
         const parsedUserData = JSON.parse(UserData);
         const accessToken = parsedUserData?.data?.accessToken;
+
         if (accessToken) {
-          const response = await client.post(`/onboarding/academy-information`, formValues, {
+          const endpoint = isScouncilPath ? '/auth/council-login' : '/onboarding/academy-information';
+          const response = await client.post(endpoint, targetFormValues, {
             headers: {
               Authorization: `Bearer ${accessToken}`,
             },
@@ -87,11 +93,7 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
 
           if (response.status === 200) {
             alert('학생 정보가 확인되었습니다');
-            if (typeof navigate === 'function') {
-              navigate('/');
-            } else {
-              console.warn('navigate 함수가 정의되지 않았습니다.');
-            }
+            navigate('/');
           } else {
             alert('오류가 발생했습니다. 다시 시도해주세요.');
           }
@@ -108,7 +110,7 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
   };
 
   const handleCertifyError = () => {
-    navigate('/register/errorcheck');
+    navigate('/register/errorapply');
   };
 
   return (
@@ -122,13 +124,13 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
                 type="text"
                 placeholder="아이디"
                 className="w-[420px]"
-                {...register('id', {
+                {...register('accountId', {
                   required: '아이디는 필수 입력입니다.',
                 })}
-                aria-invalid={isSubmitted ? (errors.id ? 'true' : 'false') : undefined}
+                aria-invalid={isSubmitted ? (errors.accountId ? 'true' : 'false') : undefined}
               />
               <div className="mt-3"></div>
-              {errors.id && <small className=" text-[13px] text-red-600">{errors.id.message}</small>}
+              {errors.accountId && <small className=" text-[13px] text-red-600">{errors.accountId.message}</small>}
               <Input
                 type="password"
                 placeholder="비밀번호"
@@ -236,9 +238,11 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
           </Button>
         </form>
 
-        <button onClick={handleCertifyError} className="mt-[117px] text-lg font-normal text-gray-500">
-          학생인증이 안 되시나요?
-        </button>
+        {isScouncilPath ? null : (
+          <button onClick={handleCertifyError} className="mt-[117px] text-lg font-normal text-gray-500">
+            학생인증이 안 되시나요?
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/pages/general/containers/GeneralRegisterSection.tsx
+++ b/src/pages/general/containers/GeneralRegisterSection.tsx
@@ -39,7 +39,6 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
   const formValuesScouncil = watch();
   const { sort } = useParams();
 
-  /*
   useEffect(() => {
     if (sort !== 'scouncil') {
       const storedFormValues = localStorage.getItem('formValues');
@@ -54,7 +53,7 @@ export function GeneralRegisterSection({ subSection1, buttonSection }: LoginForm
       }
     }
   }, [navigate, sort]);
-*/
+
   useEffect(() => {
     if (!isScouncilPath) {
       localStorage.setItem('formValues', JSON.stringify(formValues));

--- a/src/pages/kakao/containers/KakaoRedirect.tsx
+++ b/src/pages/kakao/containers/KakaoRedirect.tsx
@@ -14,11 +14,16 @@ const KakaoRedirect = () => {
         const response = await kakaoAuthCodeApi(AUTHORIZE_CODE);
         console.log(response);
         const res = response.data;
-        const accessToken = response.data.data.accessToken;
         localStorage.setItem('kakaoData', JSON.stringify(res));
-        localStorage.setItem('accessToken', accessToken);
 
-        navigate('/register/onboarding');
+        if (res) {
+          // res.data 객체에 name과 studentId가 존재하는지 확인
+          if (res.data?.name && res.data?.studentId) {
+            navigate('/'); // 조건을 만족하면 홈으로 이동
+          } else {
+            navigate('/register/onboarding'); // 조건을 만족하지 않으면 onboarding 페이지로 이동
+          }
+        }
       } catch (err) {
         console.log(err);
       }
@@ -27,7 +32,7 @@ const KakaoRedirect = () => {
     kakaoLogin();
   }, [AUTHORIZE_CODE, navigate]);
 
-  return <div>Loading…</div>;
+  return <div>Loading...</div>;
 };
 
 export default KakaoRedirect;


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #88 

### 기존 코드에 영향을 미치지 않는 변경사항

- 리다이렉트 창에서 넘어온 카카오 데이터에 name, studentId가 있는지 확인하고 있으면 메인으로 이동하도록 처리
- 인증 실패 시 메일 보내기 Post api 연결 완료

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..

## 3️⃣ 추후 작업할 내용

- 백엔드 학생인증 완성 되면 api 추가연결 예정입니다. 

## 4️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
