### PR TITLE
feat: 인권신고게시판 글 작성 뷰

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@toast-ui/editor": "^3.2.2",
     "@types/node": "^20.12.2",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",

--- a/src/hooks/useContentEditor.ts
+++ b/src/hooks/useContentEditor.ts
@@ -1,0 +1,106 @@
+import { RefObject, useRef } from 'react';
+import { EditorType, HookMap, PreviewStyle } from '@toast-ui/editor';
+import { FileImageUrl, PostBoardImagesResponse } from '@/types/postBoardFilesImages.ts';
+import { Editor } from '@toast-ui/react-editor';
+import { clientAuth } from '@/apis/client.ts';
+
+interface UseContentEditorReturn {
+  register: {
+    hooks: HookMap;
+    ref: RefObject<Editor>;
+    previewStyle: PreviewStyle;
+    initialEditType: EditorType;
+    hideModeSwitch: boolean;
+    language: string;
+  };
+  processContent: () => Promise<{ images: FileImageUrl[]; content: string }>;
+}
+
+/**
+ * useContentEditor 훅
+ *
+ * `ContentEditor`의 동작을 정의하는 훅입니다. `Editor` 컴포넌트에 `register` 값을 분해 할당하면 됩니다.
+ * 첨부 이미지의 처리는 아래의 단계를 따릅니다.
+ * 1. 이미지 첨부 시 이미지의 `Blob`을 `objectUrl`로 변경하여 표시
+ * 2. `processContent` 호출 시 로컬의 이미지를 업로드 시도
+ * 3. 업로드된 이미지의 URL으로 기존 objectURL을 대체
+ * 4. 업로드된 이미지 정보와 대체된 컨텐츠 문자열 반환
+ *
+ * **예시:**
+ * ```tsx
+ * const editorRef = useRef<Editor>(null);
+ * const { register, processContent } = useContentEditor('청원게시판', editorRef);
+ * return <Editor {...register} />;
+ * ```
+ */
+
+async function postBoardImages(boardCode: string, image: FormData) {
+  return await clientAuth<PostBoardImagesResponse>({
+    url: `/board/${boardCode}/files`,
+    method: 'post',
+    data: image,
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+}
+
+// TODO: Define boardCode as enum
+export function useContentEditor(boardCode: string, ref: RefObject<Editor>): UseContentEditorReturn {
+  const imageObjectUrlsRef = useRef<[File | Blob, string][]>([]);
+
+  function addImageBlobHook(file: File | Blob, callback: (url: string, text?: string) => void) {
+    if (file) {
+      const objectUrl = URL.createObjectURL(file);
+      imageObjectUrlsRef.current.push([file, objectUrl]);
+      if ('name' in file) {
+        callback(objectUrl, file.name);
+      } else {
+        callback(objectUrl, 'image');
+      }
+    }
+    return false;
+  }
+
+  async function processContent() {
+    const markdownContent = ref.current!.getInstance().getMarkdown();
+    const imageUploadPromises = imageObjectUrlsRef.current.map(([image, objectUrl]) => {
+      async function uploadImage() {
+        const formData = new FormData();
+        formData.append('images', image);
+        const imageResponse = await postBoardImages(boardCode, formData);
+        return {
+          objectUrl,
+          success: imageResponse.data.isSuccess,
+          ...(imageResponse.data.isSuccess ? { files: imageResponse.data.data.postFiles } : {}),
+        };
+      }
+
+      return uploadImage();
+    });
+    const uploadedImages = await Promise.all(imageUploadPromises);
+    const processedContent = uploadedImages.reduce((content, { objectUrl, success, files }) => {
+      if (success && files) {
+        URL.revokeObjectURL(objectUrl);
+        return content.replace(objectUrl, files[0].url);
+      }
+      return content;
+    }, markdownContent);
+    return {
+      images: uploadedImages.filter(({ files }) => files).flatMap(({ files }) => files as FileImageUrl[]),
+      content: processedContent,
+    };
+  }
+
+  return {
+    register: {
+      hooks: { addImageBlobHook },
+      ref: ref,
+      previewStyle: 'vertical',
+      initialEditType: 'wysiwyg',
+      hideModeSwitch: true,
+      language: 'ko-KR',
+    },
+    processContent,
+  };
+}

--- a/src/pages/human-rights/edit/components/ContentEditor.tsx
+++ b/src/pages/human-rights/edit/components/ContentEditor.tsx
@@ -1,0 +1,12 @@
+import { Editor, EditorProps } from '@toast-ui/react-editor';
+import { useRef } from 'react';
+
+interface ContentEditorProps
+  extends Omit<EditorProps, 'ref' | 'previewStyle' | 'initialEditType' | 'hideModeSwitch' | 'language'> {}
+
+export function ContentEditor(props: ContentEditorProps) {
+  // TODO: Intercept adding image and push to blob array, then replace image url to objectUrl
+  // TODO: react-hook-form support with compatible ref and onChange, onBlur events.
+  const editorRef = useRef<Editor>(null);
+  return <Editor ref={editorRef} {...props} />;
+}

--- a/src/pages/human-rights/edit/components/FileInput.tsx
+++ b/src/pages/human-rights/edit/components/FileInput.tsx
@@ -12,10 +12,6 @@ import {
 } from 'react';
 
 interface FileItemProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'multiple' | 'value'> {
-  // Assert value is string since value is actual string if type of input is "file"
-  // See here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#value
-  // input의 type 값이 "file"일 경우 실제로 value 값은 string 이므로 string으로 단언합니다.
-  // 정보: https://developer.mozilla.org/ko-KR/docs/Web/HTML/Element/input/file#값
   file?: File;
 }
 

--- a/src/pages/human-rights/edit/components/FileInput.tsx
+++ b/src/pages/human-rights/edit/components/FileInput.tsx
@@ -1,0 +1,104 @@
+import { cn } from '@/libs/utils.ts';
+import { FileText, Plus, Trash } from '@phosphor-icons/react';
+import {
+  ChangeEvent,
+  DragEvent,
+  forwardRef,
+  InputHTMLAttributes,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+interface FileItemProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'multiple' | 'value'> {
+  // Assert value is string since value is actual string if type of input is "file"
+  // See here: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#value
+  // input의 type 값이 "file"일 경우 실제로 value 값은 string 이므로 string으로 단언합니다.
+  // 정보: https://developer.mozilla.org/ko-KR/docs/Web/HTML/Element/input/file#값
+  file?: File;
+}
+
+export const FileInput = forwardRef<HTMLInputElement, FileItemProps>(function (
+  { file, className, onChange, ...props }: FileItemProps,
+  ref
+) {
+  const [innerFile, setInnerFile] = useState<File | null>(null);
+  const innerRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setDragging] = useState(false);
+  useImperativeHandle(ref, () => innerRef.current!, []);
+
+  useEffect(() => {
+    if (innerRef.current) {
+      const dataTransfer = new DataTransfer();
+      if (file) dataTransfer.items.add(file);
+      innerRef.current.files = dataTransfer.files;
+    }
+    setInnerFile(file ?? null);
+  }, [file]);
+
+  function clearFile() {
+    if (innerRef.current) {
+      innerRef.current.files = new DataTransfer().files;
+      innerRef.current.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
+  function fileDropHandler(evt: DragEvent<HTMLDivElement>): void {
+    evt.preventDefault();
+    setDragging(false);
+    if (innerRef.current && evt.dataTransfer.files.length > 0) {
+      innerRef.current.files = evt.dataTransfer.files;
+      innerRef.current.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  }
+
+  function dragOverHandler(evt: DragEvent<HTMLDivElement>): void {
+    evt.preventDefault();
+    setDragging(true);
+  }
+
+  function dragExitHandler(evt: DragEvent<HTMLDivElement>): void {
+    evt.preventDefault();
+    setDragging(false);
+  }
+
+  function fileChangeHandler(evt: ChangeEvent<HTMLInputElement>): void {
+    evt.preventDefault();
+    // Give priority to user's onChange -- this allows intercept files input before component process file itself.
+    // 컴포넌트 사용자의 onChange를 우선 실행하여 파일 입력을 처리하기 전에 사용자가 가로챌 수 있도록 합니다.
+    if (onChange) {
+      onChange(evt);
+    }
+    const file = evt.currentTarget.files?.item(0);
+    setInnerFile(file ? file : null);
+  }
+
+  return (
+    <div
+      className={cn('flex cursor-pointer items-center gap-4', className)}
+      onDrop={fileDropHandler}
+      onDragOver={dragOverHandler}
+      onDragExit={dragExitHandler}
+    >
+      <div
+        className={cn(
+          'flex grow items-center gap-4 rounded-md border-2 border-[#CDCDCD] p-4 text-gray-400',
+          isDragging && 'border-dashed border-primary text-gray-600',
+          innerFile && 'text-gray-600'
+        )}
+        onClick={() => innerRef.current?.showPicker()}
+      >
+        <FileText className={cn('text-gray-600', isDragging && 'motion-safe:animate-bounce')} size="32" />
+        {isDragging ? '파일을 끌어넣어 추가하기' : (innerFile?.name ?? '파일을 선택해주세요')}
+      </div>
+      <button
+        className="p-4"
+        onClick={() => (innerFile ? innerRef.current != null && clearFile() : innerRef.current?.showPicker())}
+      >
+        {innerFile ? <Trash className="text-gray-600" size="32" /> : <Plus className="text-gray-600" size="32" />}
+      </button>
+      <input ref={innerRef} type="file" className="hidden" multiple={false} onChange={fileChangeHandler} {...props} />
+    </div>
+  );
+});

--- a/src/pages/human-rights/edit/components/FileInputs.tsx
+++ b/src/pages/human-rights/edit/components/FileInputs.tsx
@@ -12,7 +12,7 @@ export function FileInputs({ className, files, onChange }: FileInputsProps) {
   const [innerFiles, setInnerFiles] = useState<File[]>([]);
 
   useEffect(() => {
-    // Do not trigger onChange if files is controlled from outside.
+    // Do not trigger onChange if files are controlled from outside.
     // 외부에서 files 값이 변경될 경우 re-render는 수행하지만 onChange 이벤트를 발생시키지 않습니다.
     if (files) setInnerFiles(files);
     else setInnerFiles([]);
@@ -24,7 +24,7 @@ export function FileInputs({ className, files, onChange }: FileInputsProps) {
       const newFiles = [...innerFiles, file];
       setInnerFiles(newFiles);
       if (onChange) onChange(newFiles);
-      // Remove file in new file input to keep input fresh.
+      // Remove the existing file in the new file input to keep input fresh.
       // 새 파일을 입력받는 input 의 파일을 제거하여 파일이 추가된 상태로 보이지 않도록 합니다.
       evt.currentTarget.files = new DataTransfer().files;
     }

--- a/src/pages/human-rights/edit/components/FileInputs.tsx
+++ b/src/pages/human-rights/edit/components/FileInputs.tsx
@@ -1,0 +1,53 @@
+import { ChangeEvent, useEffect, useState } from 'react';
+import { FileInput } from '@/pages/human-rights/edit/components/FileInput.tsx';
+import { cn } from '@/libs/utils.ts';
+
+interface FileInputsProps {
+  className?: string;
+  files?: File[];
+  onChange?: (files: File[]) => void;
+}
+
+export function FileInputs({ className, files, onChange }: FileInputsProps) {
+  const [innerFiles, setInnerFiles] = useState<File[]>([]);
+
+  useEffect(() => {
+    // Do not trigger onChange if files is controlled from outside.
+    // 외부에서 files 값이 변경될 경우 re-render는 수행하지만 onChange 이벤트를 발생시키지 않습니다.
+    if (files) setInnerFiles(files);
+    else setInnerFiles([]);
+  }, [files]);
+
+  function onNewFile(evt: ChangeEvent<HTMLInputElement>) {
+    const file = evt.currentTarget.files?.item(0);
+    if (file) {
+      const newFiles = [...innerFiles, file];
+      setInnerFiles(newFiles);
+      if (onChange) onChange(newFiles);
+      // Remove file in new file input to keep input fresh.
+      // 새 파일을 입력받는 input 의 파일을 제거하여 파일이 추가된 상태로 보이지 않도록 합니다.
+      evt.currentTarget.files = new DataTransfer().files;
+    }
+  }
+
+  function onFileChange(idx: number, evt: ChangeEvent<HTMLInputElement>) {
+    const file = evt.currentTarget.files?.item(0);
+    const newFiles = innerFiles;
+    if (file) {
+      newFiles[idx] = file;
+    } else {
+      newFiles.splice(idx, 1);
+    }
+    if (onChange) onChange(newFiles);
+    setInnerFiles([...newFiles]);
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-6', className)}>
+      {innerFiles.map((file, idx) => (
+        <FileInput key={idx} file={file} onChange={(evt) => onFileChange(idx, evt)} />
+      ))}
+      <FileInput onChange={onNewFile} />
+    </div>
+  );
+}

--- a/src/pages/human-rights/edit/components/FrontmatterEditor.tsx
+++ b/src/pages/human-rights/edit/components/FrontmatterEditor.tsx
@@ -1,0 +1,50 @@
+import { Fragment } from 'react';
+import { FrontmatterInput } from '@/pages/human-rights/edit/components/FrontmatterInput.tsx';
+import { cn } from '@/libs/utils.ts';
+import { FieldValues, Path, UseFormRegister } from 'react-hook-form';
+
+interface FrontmatterEditProps<TFieldValues extends FieldValues> {
+  id: string;
+  items: {
+    id: string;
+    term: string;
+    required?: boolean;
+    value?: string;
+    disabled?: boolean;
+    registerPath?: Path<TFieldValues>;
+  }[];
+  register?: UseFormRegister<TFieldValues>;
+}
+
+export function FrontmatterEditor<TFieldValues extends FieldValues = NonNullable<unknown>>({
+  id,
+  items,
+  register,
+}: FrontmatterEditProps<TFieldValues>) {
+  return (
+    <div className="grid grid-cols-[auto_minmax(0,_1fr)] items-center gap-x-4 gap-y-3">
+      {items.map(({ id: itemId, term, required, value, disabled, registerPath }) => (
+        <Fragment key={`${id}_${itemId}_wrapper`}>
+          <label
+            htmlFor={`${id}_${itemId}`}
+            className={cn(
+              'w-fit font-semibold text-[#484848]',
+              required && 'before:absolute before:-translate-x-full before:text-[#ff0000] before:content-["*"]'
+            )}
+          >
+            {term}
+          </label>
+          {/* Input 컴포넌트를 사용하려 했으나 Input 컴포넌트의 기본 스타일의 크기가 규격과 맞지 않네요... */}
+          <FrontmatterInput
+            id={`${id}_${itemId}`}
+            className="px-2 py-2"
+            required={required}
+            value={value}
+            disabled={disabled}
+            {...(register && registerPath ? register(registerPath) : {})}
+          />
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/human-rights/edit/components/FrontmatterInput.tsx
+++ b/src/pages/human-rights/edit/components/FrontmatterInput.tsx
@@ -4,7 +4,13 @@ import { cn } from '@/libs/utils.ts';
 // TODO: 기존 Input 디자인과 상이하여 새로운 컴포넌트인 `FrontmatterInput` 생성, 추후 디자인팀과 논의하여 다른 페이지의 폼과 동일한 형태가 되도록 리팩토링 필요
 const FrontmatterInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
   ({ className, ...props }, ref) => {
-    return <input className={cn('w-fit rounded-md border-2 border-[#CDCDCD]', className)} ref={ref} {...props} />;
+    return (
+      <input
+        className={cn('w-fit rounded-md border-2 border-[#CDCDCD] disabled:bg-[#CDCDCD]', className)}
+        ref={ref}
+        {...props}
+      />
+    );
   }
 );
 

--- a/src/pages/human-rights/edit/components/FrontmatterInput.tsx
+++ b/src/pages/human-rights/edit/components/FrontmatterInput.tsx
@@ -1,0 +1,11 @@
+import { forwardRef, InputHTMLAttributes } from 'react';
+import { cn } from '@/libs/utils.ts';
+
+// TODO: 기존 Input 디자인과 상이하여 새로운 컴포넌트인 `FrontmatterInput` 생성, 추후 디자인팀과 논의하여 다른 페이지의 폼과 동일한 형태가 되도록 리팩토링 필요
+const FrontmatterInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, ...props }, ref) => {
+    return <input className={cn('w-fit rounded-md border-2 border-[#CDCDCD]', className)} ref={ref} {...props} />;
+  }
+);
+
+export { FrontmatterInput };

--- a/src/pages/human-rights/edit/containers/ArticleFooter.tsx
+++ b/src/pages/human-rights/edit/containers/ArticleFooter.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/libs/utils.ts';
+import { ReactNode } from 'react';
+
+interface ArticleFooterProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+export function ArticleFooter({ children, className }: ArticleFooterProps) {
+  return (
+    <footer
+      className={cn('flex justify-center px-10 md:px-[72px] lg:px-[200px] xl:px-[200px] xxl:px-[200px]', className)}
+    >
+      <div className="mb-6 flex w-full max-w-[1040px] flex-col gap-2">{children}</div>
+    </footer>
+  );
+}

--- a/src/pages/human-rights/edit/containers/ArticleHeader.tsx
+++ b/src/pages/human-rights/edit/containers/ArticleHeader.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/libs/utils.ts';
+import { ReactNode } from 'react';
+
+interface ArticleHeaderProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+export function ArticleHeader({ children, className }: ArticleHeaderProps) {
+  return (
+    <header
+      className={cn('flex justify-center px-10 md:px-[72px] lg:px-[200px] xl:px-[200px] xxl:px-[200px]', className)}
+    >
+      <div className="mb-6 flex w-full max-w-[1040px] flex-col gap-2">{children}</div>
+    </header>
+  );
+}

--- a/src/pages/human-rights/edit/containers/Container.tsx
+++ b/src/pages/human-rights/edit/containers/Container.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from 'react';
+import { cn } from '@/libs/utils.ts';
+
+interface ContainerProps {
+  className?: string;
+  children: ReactNode;
+}
+
+// TODO: `human-rights/[id]/components/Container.tsx`와 병합
+export function Container({ className, children }: ContainerProps) {
+  return (
+    <section
+      className={cn('flex justify-center px-10 md:px-[72px] lg:px-[200px] xl:px-[200px] xxl:px-[200px]', className)}
+    >
+      <div className="w-full max-w-[1040px] py-20">{children}</div>
+    </section>
+  );
+}

--- a/src/pages/human-rights/edit/form.ts
+++ b/src/pages/human-rights/edit/form.ts
@@ -1,0 +1,44 @@
+import { DefaultValues, useFieldArray, UseFieldArrayReturn, useForm } from 'react-hook-form';
+import { MockHumanRightsPostEditRequest, MockHumanRightsPostEditRequestSchema } from '@/pages/human-rights/schema.ts';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+type PrefixKeys<T, P extends string> = {
+  [K in keyof T as K extends string ? `${P}${Capitalize<K>}` : never]: T[K];
+};
+
+function prefixKeys<T extends object, P extends string>(obj: T, prefix: P): PrefixKeys<T, P> {
+  function capitalize<S extends string>(string: S): Capitalize<S> {
+    return (string[0].toUpperCase() + string.slice(1)) as Capitalize<S>;
+  }
+
+  return Object.fromEntries(Object.entries(obj).map(([k, v]) => [`${prefix}${capitalize(k)}`, v])) as PrefixKeys<T, P>;
+}
+
+export function useHumanRightsForm(defaultValues?: DefaultValues<MockHumanRightsPostEditRequest>) {
+  const form = useForm<MockHumanRightsPostEditRequest>({
+    resolver: zodResolver(MockHumanRightsPostEditRequestSchema),
+    mode: 'onBlur',
+    defaultValues,
+  });
+  const victimFieldArray: PrefixKeys<UseFieldArrayReturn<MockHumanRightsPostEditRequest>, 'victim'> = prefixKeys(
+    useFieldArray<MockHumanRightsPostEditRequest>({
+      control: form.control,
+      name: 'metadata.victims',
+      rules: { minLength: 1 },
+    }),
+    'victim'
+  );
+  const invaderFieldArray: PrefixKeys<UseFieldArrayReturn<MockHumanRightsPostEditRequest>, 'invader'> = prefixKeys(
+    useFieldArray<MockHumanRightsPostEditRequest>({
+      control: form.control,
+      name: 'metadata.invaders',
+      rules: { minLength: 1 },
+    }),
+    'invader'
+  );
+  return {
+    ...form,
+    ...victimFieldArray,
+    ...invaderFieldArray,
+  };
+}

--- a/src/pages/human-rights/edit/form.ts
+++ b/src/pages/human-rights/edit/form.ts
@@ -2,6 +2,17 @@ import { DefaultValues, useFieldArray, UseFieldArrayReturn, useForm } from 'reac
 import { MockHumanRightsPostEditRequest, MockHumanRightsPostEditRequestSchema } from '@/pages/human-rights/schema.ts';
 import { zodResolver } from '@hookform/resolvers/zod';
 
+/**
+ * PrefixKeys 유틸리티
+ * Object의 각 key에 camelCase를 유지하며 접두사를 붙입니다.
+ *
+ * 예시:
+ * ```typescript
+ * const original: OriginalObject = { test: 'hello', world: 'vanquisher' };
+ * const prefixed: PrefixKeys<OriginalObject, 'hello'> = prefixKeys(original, 'hello');
+ * console.log(prefixed) // { helloTest: 'hello', helloWorld: 'vanquisher' }
+ * ```
+ */
 type PrefixKeys<T, P extends string> = {
   [K in keyof T as K extends string ? `${P}${Capitalize<K>}` : never]: T[K];
 };

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -72,6 +72,7 @@ export function HumanRightsEditPage() {
   }
 
   function submitForm(data: MockHumanRightsPostEditRequest) {
+    // TODO: Submit post request
     console.log('submit requested', data);
   }
 
@@ -79,7 +80,6 @@ export function HumanRightsEditPage() {
     (async () => await trigger())();
   }, [trigger]);
 
-  console.log(errors);
   return (
     <article className="mt-[200px]">
       {/* TODO: EditLayout에 `className` property 추가 필요, divider 추가 필요 */}

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -174,13 +174,16 @@ export function HumanRightsEditPage() {
           <ol className="mb-6">
             {invaderFields.map((field, index) => (
               <li key={field.id}>
-                <div className="mb-6 flex items-center gap-2">
-                  <h3 className="text-lg font-semibold text-gray-700">[침해자{index + 1}]</h3>
+                <div className="relative mb-6">
                   {index > 0 && (
-                    <button onClick={() => invaderRemove(index)}>
-                      <MinusCircle />
+                    <button
+                      className="absolute top-1/2 -translate-x-[calc(100%+2px)] -translate-y-1/2 text-[#979797]"
+                      onClick={() => invaderRemove(index)}
+                    >
+                      <MinusCircle size="20" />
                     </button>
                   )}
+                  <h3 className="text-lg font-semibold text-gray-700">[침해자{index + 1}]</h3>
                 </div>
                 <FrontmatterEditor
                   id={field.id}

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -1,0 +1,272 @@
+import { Input } from '@/components/ui/input.tsx';
+import { Editor } from '@toast-ui/react-editor';
+import { RegisterButton } from '@/components/Buttons/BoardActionButtons.tsx';
+import { FrontmatterEditor } from '@/pages/human-rights/edit/components/FrontmatterEditor.tsx';
+import { cn } from '@/libs/utils.ts';
+import { ArticleHeader } from '@/pages/human-rights/edit/containers/ArticleHeader.tsx';
+import { Container } from '@/pages/human-rights/edit/containers/Container.tsx';
+import { ArticleFooter } from '@/pages/human-rights/edit/containers/ArticleFooter.tsx';
+import { MinusCircle, Plus } from '@phosphor-icons/react';
+import { useHumanRightsForm } from '@/pages/human-rights/edit/form.ts';
+import { MockHumanRightsPostEditRequest } from '@/pages/human-rights/schema.ts';
+import { FileInputs } from '@/pages/human-rights/edit/components/FileInputs.tsx';
+import { useEffect, useRef, useState } from 'react';
+
+const disclaimer = `학생인권위원회는 인권침해구제와 관련하여 아래와 같이 개인정보를 수집·이용하고자 합니다.
+
+✔수집 및 이용 대상
+학생인권위원회
+
+✔개인정보 수집 및 이용에 대한 목적
+학내 인권침해 사례 조사 및 해결을 위한 답변 수집
+
+✔개인정보 수집 항목
+이름, 학과, 학번, 전화번호
+
+✔개인정보 보관 일자
+2024년 5월 23일 ~ 2024년 12월 31일
+
+` as const;
+
+export function HumanRightsEditPage() {
+  // TODO: 수정 기능 추가
+  const {
+    register,
+    handleSubmit,
+    victimFields,
+    victimAppend,
+    victimRemove,
+    invaderFields,
+    invaderAppend,
+    invaderRemove,
+    setValue,
+    trigger,
+    formState: { errors },
+  } = useHumanRightsForm({
+    metadata: {
+      reporter: {
+        name: 'test',
+        studentId: 'test',
+        department: 'test',
+      },
+      victims: [
+        {
+          name: '',
+        },
+      ],
+      invaders: [
+        {
+          name: '',
+        },
+      ],
+    },
+  });
+  const editorRef = useRef<Editor>(null);
+  // 파일의 재렌더링은 `FileInputs`에서 처리하고 있으므로 useRef 사용
+  const filesRef = useRef<File[]>([]);
+  const [disclaimerAgreed, setDisclaimerAgreed] = useState(false);
+
+  function contentChangeHandler() {
+    if (editorRef.current) {
+      setValue('content', editorRef.current.getInstance().getMarkdown());
+    }
+  }
+
+  function contentBlurHandler() {
+    (async () => await trigger('content'))();
+  }
+
+  function submitForm(data: MockHumanRightsPostEditRequest) {
+    console.log('submit requested', data);
+  }
+
+  useEffect(() => {
+    (async () => await trigger())();
+  }, [trigger]);
+
+  console.log(errors);
+  return (
+    <article className="mt-[200px]">
+      {/* TODO: EditLayout에 `className` property 추가 필요, divider 추가 필요 */}
+      <ArticleHeader>
+        <h1 className="text-5xl font-bold">인권신고게시판</h1>
+      </ArticleHeader>
+      <hr className="bg-[#E7E7E7]" />
+      <Container>
+        <section className="mb-16">
+          <h2
+            className={cn(
+              'mb-6 text-2xl font-semibold',
+              'before:absolute before:-translate-x-full before:text-[#ff0000] before:content-["*"]'
+            )}
+          >
+            신고자 정보 입력
+          </h2>
+          <FrontmatterEditor
+            id="reporter"
+            register={register}
+            items={[
+              { id: 'name', term: '성명', required: true, disabled: true, registerPath: 'metadata.reporter.name' },
+              {
+                id: 'student_id',
+                term: '학번',
+                required: true,
+                disabled: true,
+                registerPath: 'metadata.reporter.studentId',
+              },
+              {
+                id: 'department',
+                term: '학과/부',
+                required: true,
+                disabled: true,
+                registerPath: 'metadata.reporter.department',
+              },
+              { id: 'contact', term: '연락처', required: true, registerPath: 'metadata.reporter.contact' },
+            ]}
+          />
+        </section>
+        <section className="mb-16">
+          <h2 className="text-2xl font-semibold">피침해자 정보 입력</h2>
+          <p className="mb-6 text-[#979797]">빈칸을 모두 채우지 않아도 되며,알고 있는 정보를 기입하여 주세요.</p>
+          <ol className="mb-6 flex flex-col gap-6">
+            {victimFields.map((field, index) => (
+              <li key={field.id}>
+                <div className="relative mb-6">
+                  {index > 0 && (
+                    <button
+                      className="absolute top-1/2 -translate-x-[calc(100%+2px)] -translate-y-1/2 text-[#979797]"
+                      onClick={() => victimRemove(index)}
+                    >
+                      <MinusCircle size="20" />
+                    </button>
+                  )}
+                  <h3 className="text-lg font-semibold text-gray-700">[피침해자{index + 1}]</h3>
+                </div>
+                <FrontmatterEditor
+                  id={field.id}
+                  register={register}
+                  items={[
+                    {
+                      id: `${field.id}_name`,
+                      term: '성명',
+                      required: true,
+                      registerPath: `metadata.victims.${index}.name`,
+                    },
+                    { id: `${field.id}_student_id`, term: '학번', registerPath: `metadata.victims.${index}.studentId` },
+                    {
+                      id: `${field.id}_department`,
+                      term: '학과/부',
+                      registerPath: `metadata.victims.${index}.department`,
+                    },
+                  ]}
+                />
+              </li>
+            ))}
+          </ol>
+          <button className="flex items-center gap-2 text-[#979797]" onClick={() => victimAppend({ name: '' })}>
+            <Plus />
+            피침해자 정보 추가하기
+          </button>
+        </section>
+        <section className="mb-16">
+          <h2 className="text-2xl font-semibold">침해자(신고 대상자) 정보 입력</h2>
+          <p className="mb-6 text-[#979797]">빈칸을 모두 채우지 않아도 되며,알고 있는 정보를 기입하여 주세요.</p>
+          <ol className="mb-6">
+            {invaderFields.map((field, index) => (
+              <li key={field.id}>
+                <div className="mb-6 flex items-center gap-2">
+                  <h3 className="text-lg font-semibold text-gray-700">[침해자{index + 1}]</h3>
+                  {index > 0 && (
+                    <button onClick={() => invaderRemove(index)}>
+                      <MinusCircle />
+                    </button>
+                  )}
+                </div>
+                <FrontmatterEditor
+                  id={field.id}
+                  register={register}
+                  items={[
+                    {
+                      id: `${field.id}_name`,
+                      term: '성명',
+                      required: true,
+                      registerPath: `metadata.invaders.${index}.name`,
+                    },
+                    {
+                      id: `${field.id}_student_id`,
+                      term: '학번',
+                      registerPath: `metadata.invaders.${index}.studentId`,
+                    },
+                    {
+                      id: `${field.id}_department`,
+                      term: '학과/부',
+                      registerPath: `metadata.invaders.${index}.department`,
+                    },
+                  ]}
+                />
+              </li>
+            ))}
+          </ol>
+          <button className="flex items-center gap-2 text-[#979797]" onClick={() => invaderAppend({ name: '' })}>
+            <Plus />
+            침해자 정보 추가하기
+          </button>
+        </section>
+        <section className="mb-16 flex flex-col gap-6">
+          <h2
+            className={cn(
+              'text-2xl font-semibold',
+              'before:absolute before:-translate-x-full before:text-[#ff0000] before:content-["*"]'
+            )}
+          >
+            피해 사실 기술
+          </h2>
+          <Input id="title" type="text" placeholder="제목을 입력하세요." {...register('title')} />
+          <Editor
+            ref={editorRef}
+            id="content"
+            height="620px"
+            initialValue=" "
+            placeholder="글을 작성해주세요"
+            previewStyle="vertical"
+            initialEditType="wysiwyg"
+            useCommandShortcut={true}
+            hideModeSwitch={true}
+            onChange={contentChangeHandler}
+            onBlur={contentBlurHandler}
+            language="ko-KR"
+          />
+        </section>
+        <section className="mb-16">
+          <h2 className="mb-6 text-2xl font-semibold">증거 및 자료 첨부</h2>
+          <FileInputs onChange={(files) => (filesRef.current = files)} />
+        </section>
+        <section className="flex flex-col gap-6">
+          <h2 className="text-2xl font-semibold">개인정보 수집 및 이용에 관한 동의</h2>
+          <pre className="rounded-md border-2 border-[#CDCDCD] px-8 py-6">{disclaimer}</pre>
+          <div className="flex justify-between">
+            <p className='before:absolute before:-translate-x-full before:text-[#ff0000] before:content-["*"]'>
+              위와 같이 개인정보를 수집·이용하는 데 동의하십니까?
+            </p>
+            <div className="flex items-center gap-2">
+              <label htmlFor="agree_disclaimer">동의합니다</label>
+              <input
+                id="agree_disclaimer"
+                type="checkbox"
+                checked={disclaimerAgreed}
+                onChange={(evt) => setDisclaimerAgreed(evt.target.checked)}
+              />
+            </div>
+          </div>
+        </section>
+      </Container>
+      <ArticleFooter>
+        <RegisterButton
+          className="self-end"
+          disabled={!disclaimerAgreed || Object.keys(errors).length > 0}
+          onClick={handleSubmit(submitForm)}
+        />
+      </ArticleFooter>
+    </article>
+  );
+}

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -44,11 +44,6 @@ export function HumanRightsEditPage() {
     formState: { errors },
   } = useHumanRightsForm({
     metadata: {
-      reporter: {
-        name: 'test',
-        studentId: 'test',
-        department: 'test',
-      },
       victims: [
         {
           name: '',

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -11,6 +11,7 @@ import { useHumanRightsForm } from '@/pages/human-rights/edit/form.ts';
 import { MockHumanRightsPostEditRequest } from '@/pages/human-rights/schema.ts';
 import { FileInputs } from '@/pages/human-rights/edit/components/FileInputs.tsx';
 import { useEffect, useRef, useState } from 'react';
+import { useContentEditor } from '@/hooks/useContentEditor.ts';
 
 const disclaimer = `학생인권위원회는 인권침해구제와 관련하여 아래와 같이 개인정보를 수집·이용하고자 합니다.
 
@@ -30,6 +31,8 @@ const disclaimer = `학생인권위원회는 인권침해구제와 관련하여 
 
 export function HumanRightsEditPage() {
   // TODO: 수정 기능 추가
+
+  /* Register form hooks */
   const {
     register,
     handleSubmit,
@@ -56,7 +59,10 @@ export function HumanRightsEditPage() {
       ],
     },
   });
+  // 에디터 기능 훅
   const editorRef = useRef<Editor>(null);
+  // TODO: 백엔드 구현 시 processContent 추가
+  const { register: registerEditor } = useContentEditor('인권신고게시판', editorRef);
   // 파일의 재렌더링은 `FileInputs`에서 처리하고 있으므로 useRef 사용
   const filesRef = useRef<File[]>([]);
   const [disclaimerAgreed, setDisclaimerAgreed] = useState(false);
@@ -71,7 +77,7 @@ export function HumanRightsEditPage() {
     (async () => await trigger('content'))();
   }
 
-  function submitForm(data: MockHumanRightsPostEditRequest) {
+  async function submitForm(data: MockHumanRightsPostEditRequest) {
     // TODO: Submit post request
     console.log('submit requested', data);
   }
@@ -221,18 +227,13 @@ export function HumanRightsEditPage() {
           </h2>
           <Input id="title" type="text" placeholder="제목을 입력하세요." {...register('title')} />
           <Editor
-            ref={editorRef}
-            id="content"
             height="620px"
             initialValue=" "
             placeholder="글을 작성해주세요"
-            previewStyle="vertical"
-            initialEditType="wysiwyg"
             useCommandShortcut={true}
-            hideModeSwitch={true}
             onChange={contentChangeHandler}
             onBlur={contentBlurHandler}
-            language="ko-KR"
+            {...registerEditor}
           />
         </section>
         <section className="mb-16">

--- a/src/pages/human-rights/schema.ts
+++ b/src/pages/human-rights/schema.ts
@@ -5,27 +5,23 @@ export type MockHumanRightsReporter = z.infer<typeof MockHumanRightsReporterSche
 export type MockHumanRightsPostEditRequest = z.infer<typeof MockHumanRightsPostEditRequestSchema>;
 
 export const MockHumanRightsPersonSchema = z.object({
-  name: z.string(),
-  studentId: z.string().optional(),
-  department: z.string().optional(),
+  name: z.string().min(1),
+  studentId: z.string().min(1).optional(),
+  department: z.string().min(1).optional(),
 });
 
 export const MockHumanRightsReporterSchema = MockHumanRightsPersonSchema.required().extend({
-  contact: z.string(),
+  contact: z.string().min(1),
 });
 
 export const MockHumanRightsPostEditRequestSchema = z.object({
-  postId: z.number(),
-  studentId: z.string(),
-  authorName: z.string(),
-  title: z.string(),
+  postId: z.number().optional(),
+  title: z.string().min(1),
   metadata: z.object({
     reporter: MockHumanRightsReporterSchema,
-    victims: MockHumanRightsPersonSchema.array(),
-    invaders: MockHumanRightsPersonSchema.array(),
+    victims: MockHumanRightsPersonSchema.array().min(1),
+    invaders: MockHumanRightsPersonSchema.array().min(1),
   }),
-  content: z.string(),
-  createdAt: z.string().date(),
-  lastEditedAt: z.string().date().nullable(),
-  postFileList: z.number().array(),
+  content: z.string().min(1),
+  postFileList: z.number().array().default([]),
 });

--- a/src/pages/human-rights/schema.ts
+++ b/src/pages/human-rights/schema.ts
@@ -1,0 +1,31 @@
+import z from 'zod';
+
+export type MockHumanRightsPerson = z.infer<typeof MockHumanRightsPersonSchema>;
+export type MockHumanRightsReporter = z.infer<typeof MockHumanRightsReporterSchema>;
+export type MockHumanRightsPostEditRequest = z.infer<typeof MockHumanRightsPostEditRequestSchema>;
+
+export const MockHumanRightsPersonSchema = z.object({
+  name: z.string(),
+  studentId: z.string().optional(),
+  department: z.string().optional(),
+});
+
+export const MockHumanRightsReporterSchema = MockHumanRightsPersonSchema.required().extend({
+  contact: z.string(),
+});
+
+export const MockHumanRightsPostEditRequestSchema = z.object({
+  postId: z.number(),
+  studentId: z.string(),
+  authorName: z.string(),
+  title: z.string(),
+  metadata: z.object({
+    reporter: MockHumanRightsReporterSchema,
+    victims: MockHumanRightsPersonSchema.array(),
+    invaders: MockHumanRightsPersonSchema.array(),
+  }),
+  content: z.string(),
+  createdAt: z.string().date(),
+  lastEditedAt: z.string().date().nullable(),
+  postFileList: z.number().array(),
+});

--- a/src/pages/human-rights/schema.ts
+++ b/src/pages/human-rights/schema.ts
@@ -6,8 +6,8 @@ export type MockHumanRightsPostEditRequest = z.infer<typeof MockHumanRightsPostE
 
 export const MockHumanRightsPersonSchema = z.object({
   name: z.string().min(1),
-  studentId: z.string().min(1).optional(),
-  department: z.string().min(1).optional(),
+  studentId: z.string().optional(),
+  department: z.string().optional(),
 });
 
 export const MockHumanRightsReporterSchema = MockHumanRightsPersonSchema.required().extend({

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -7,6 +7,7 @@ import { IntroEditPage } from './intro/IntroEdit/page';
 import { AuditPage } from './audit/page';
 import { AuditDetailPage } from './audit/auditDetail/page';
 import { AuditEditPage } from './audit/auditEdit/page';
+import { HumanRightsEditPage } from './human-rights/edit/page';
 import { PartnershipPage } from './partnership/page';
 import { PetitionNoticePage } from './petition-notice/page';
 import { PetitionNoticeEditPage } from './petition-notice/edit/page';
@@ -38,6 +39,7 @@ export {
   AuditPage,
   AuditDetailPage,
   AuditEditPage,
+  HumanRightsEditPage,
   PartnershipPage,
   PetitionNoticePage,
   PetitionNoticeEditPage,

--- a/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
+++ b/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
@@ -13,12 +13,8 @@ import history from '@/hooks/useHistory';
 import { usePostBoardPosts } from '@/hooks/api/post/usePostBoardPosts';
 import { GUIDE_LINE } from '../components/GuideLine';
 import { useDelBoardFiles } from '@/hooks/api/del/useDelBoardFiles';
+import { HookMap } from '@toast-ui/editor';
 
-type HookMap = {
-  addImageBlobHook?: (blob: File, callback: HookCallback) => void;
-};
-
-type HookCallback = (url: string, text?: string) => void;
 
 export function PetitionNoticeEditorSection() {
   const titleRef = useRef<HTMLInputElement>(null);
@@ -168,7 +164,7 @@ export function PetitionNoticeEditorSection() {
   }, [initialContent]);
 
   const hooks: HookMap = {
-    addImageBlobHook: async (blob: File, callback: HookCallback) => {
+    addImageBlobHook: async (blob: File | Blob, callback: (url: string, text?: string) => void) => {
       if (blob !== null) {
         const file = new FormData();
         file.append('images', blob);

--- a/src/pages/router.tsx
+++ b/src/pages/router.tsx
@@ -37,8 +37,7 @@ export function MainRouter() {
         <Route path="/audit/edit" element={<i.AuditEditPage />} />
         <Route path="/audit/:id/patch" element={<i.AuditPatchPage />} />
         {/* 4-1. 인권신고게시판*/}
-        <Route path="/human-rights/edit" element={<i.HumanRightsEditPage />} />
-        <Route path="/human-rights/:id/edit" element={<i.HumanRightsEditPage />} />
+        <Route path="/human-rights/:id?/edit" element={<i.HumanRightsEditPage />} />
         {/* 개인정보이용약관 */}
         <Route path="/personal-data" element={<i.PersonalDataPage />} />
       </Route>

--- a/src/pages/router.tsx
+++ b/src/pages/router.tsx
@@ -36,6 +36,9 @@ export function MainRouter() {
         <Route path="/audit/:id" element={<i.AuditDetailPage />} />
         <Route path="/audit/edit" element={<i.AuditEditPage />} />
         <Route path="/audit/:id/patch" element={<i.AuditPatchPage />} />
+        {/* 4-1. 인권신고게시판*/}
+        <Route path="/human-rights/edit" element={<i.HumanRightsEditPage />} />
+        <Route path="/human-rights/:id/edit" element={<i.HumanRightsEditPage />} />
         {/* 개인정보이용약관 */}
         <Route path="/personal-data" element={<i.PersonalDataPage />} />
       </Route>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,13 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
-
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
@@ -13,18 +16,28 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ],
+      "@toast-ui/editor": [
+        "./node_modules/@toast-ui/editor/types"
+      ]
     }
   },
-  "include": ["src", "react-slick.d.ts"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": [
+    "src",
+    "react-slick.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,6 +3188,7 @@ __metadata:
     "@radix-ui/react-tabs": "npm:^1.0.4"
     "@radix-ui/react-tooltip": "npm:^1.0.7"
     "@tanstack/react-query": "npm:^5.28.9"
+    "@toast-ui/editor": "npm:^3.2.2"
     "@toast-ui/react-editor": "npm:^3.2.3"
     "@types/node": "npm:^20.12.2"
     "@types/react": "npm:^18.2.66"


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #191 

### 기존 코드에 영향을 미치지 않는 변경사항
- 신고자, 침해/피침해자 정보를 작성하기 위한 폼의 input인 `FrontmatterInput`을 작성했습니다.
  - 기존 `Input`을 활용하려 했으나, 디자인이 인권신고게시판의 경우에만 달라 임의의 컴포넌트를 작성했습니다. 디자인 단계에서 수정이 필요해 보입니다.
- 신고자, 침해/피침해자 정보를 작성하기 위한 `key-value` 형식의 폼인 `FrontmatterEditor`를 작성했습니다.
  - 기본적인 레이아웃 작업을 위한 `ArticleHeader`, `ArticleFooter`, `Container` 컴포넌트를 작성했습니다.
  - 인권신고 열람 뷰 등에서 이미 일부를 사용하고 있으므로, epic branch로 병합한 후 컴포넌트 관계를 다시 설정할 예정입니다.
- 단일 파일 입력을 위한 `FileInput` 컴포넌트를 작성했습니다.
- `FileInput` 컴포넌트를 기반으로 다중 파일 입력이 가능한 `FileInputs`를 작성했습니다.
- `zod`와 `react-hook-form`을 결합하여 form 상태 관리 및 검증을 수행하는 `useHumanRightsForm()` 훅을 작성했습니다.
  - 이 과정에서 zod Schema를 기반으로 `MockHumanRightsPostEditRequest` 타입을 작성했습니다.
  - 타입 정의는 epic branch 병합 후 하나의 파일로 합칠 예정입니다.
- Editor의 이미지 처리 및 산출물을 담당하는 `useContentEditor(boardCode: string, ref: RefObject<Editor>)` 훅을 추가했습니다.

### 기존 코드에 영향을 미치는 변경사항
- router에 `human-rights/:id?/edit` 라우트를 추가했습니다(id 프로퍼티의 유무에 따라 글 작성과 수정을 HumanRightsEditPage가 모두 수행할 수 있습니다).
- `zod`로 `react-hook-form`의 Form validation을 수행하기 위한 `@hookform/resolvers` 패키지를 설치했습니다.

### 버그 픽스
- `@toast-ui/editor`의 타입 정의가 제대로 불러와지지 않는 문제를 해결하였습니다.
  - 해결을 위해 `devDependencies`에 `@toast-ui/editor`를 추가했습니다.
  - `@toast-ui/editor`의 타입 정의 경로가 올바르지 않아 수동으로 `path`를 추가했습니다. (See [tui.editor#3197](https://github.com/nhn/tui.editor/issues/3197))
- `PetitionNoticeEditorSection`의 `addImageBlobHook`의 잘못된 타입을 수정했습니다.

### ✚ 피그마

#191 참고바랍니다.

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..

## 3️⃣ 추후 작업할 내용
- 게시글 생성, 수정에 따른 기본값 지정
- 게시글 등록, 수정시 다른 요청을 전송하도록 작업
- 데이터 fetch를 위한 mockQuery 작성(MSW 사용?)

## 4️⃣ 체크리스트

- [X] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
