### PR TITLE
fix(human-rights): `usePatchPost`에 `id` 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,5 @@
   "resolutions": {
     "rollup": "4.24.0"
   },
-  "packageManager": "yarn@4.5.1"
+  "packageManager": "yarn@4.5.3"
 }

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -275,7 +275,7 @@ export function HumanRightsEditPage() {
     const data: HumanRightsPostEditRequest = HumanRightsPostEditRequestSchema.parse(formData);
     if (postId) {
       patchPost(
-        { post: data },
+        { id: postId, post: data },
         {
           onSuccess: (data) => {
             queryClient

--- a/src/pages/human-rights/hooks/mutations/usePatchPost.ts
+++ b/src/pages/human-rights/hooks/mutations/usePatchPost.ts
@@ -13,15 +13,16 @@ export interface UsePatchPostOptions<TPostRequest> {
 }
 
 interface PatchPostVariables<T> {
+  id: number;
   post: T;
 }
 
 export function usePatchPost<TPostRequest>({ boardCode, mutationOptions }: UsePatchPostOptions<TPostRequest>) {
-  return useStuMutation(async ({ post }) => {
+  return useStuMutation(async ({ id, post }) => {
     return (
       await clientAuth<ApiResponse<number>>({
         method: 'patch',
-        url: `/board/${boardCode}/posts`,
+        url: `/board/${boardCode}/posts/${id}`,
         data: post,
       })
     ).data;


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- related: #338

`usePatchPost`에 `id` 필드를 추가했습니다.

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

- yarn 버전을 `4.5.3`으로 업데이트했습니다.

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..

## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트

- [X] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
