### PR TITLE
fix(human-rights): `OFFICIAL` 타입의 댓글이 잘못 핸들링되는 문제

### DIFF
--- a/src/pages/human-rights/[id]/components/PostFooter.tsx
+++ b/src/pages/human-rights/[id]/components/PostFooter.tsx
@@ -3,6 +3,7 @@ import { buttonVariants } from '@/components/ui/button.tsx';
 import { List, Pencil } from '@phosphor-icons/react';
 import { Skeleton } from '@/components/ui/skeleton.tsx';
 import { ArticleFooter } from '@/pages/human-rights/containers/ArticleFooter.tsx';
+import { cn } from '@/libs/utils.ts';
 
 interface PostFooterProps {
   boardUrl: string;
@@ -19,12 +20,12 @@ export function PostFooter({ boardUrl, deletable, editable, editUrl, onDelete, c
       <div className="flex w-full max-w-[1040px] justify-end gap-4">
         {deletable && <DeleteButton onClick={onDelete} />}
         {editable && (
-          <a className={buttonVariants({ variant: 'List_Edit' })} href={editUrl}>
+          <a className={cn(buttonVariants({ variant: 'List_Edit' }), 'select-none')} href={editUrl}>
             <Pencil className="text-lg" />
             <p className="text-lg">편집</p>
           </a>
         )}
-        <a className={buttonVariants({ variant: 'List_Edit' })} href={boardUrl}>
+        <a className={cn(buttonVariants({ variant: 'List_Edit' }), 'select-none')} href={boardUrl}>
           <List className="text-lg" />
           <p className="text-lg">목록</p>
         </a>

--- a/src/pages/human-rights/edit/components/FileInput.tsx
+++ b/src/pages/human-rights/edit/components/FileInput.tsx
@@ -109,7 +109,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileItemProps>(function (
         )}
         onClick={() => innerRef.current?.showPicker()}
       >
-        <FileText className={cn('text-gray-600', isDragging && 'motion-safe:animate-bounce')} size="32" />
+        <FileText className={cn('select-none text-gray-600', isDragging && 'motion-safe:animate-bounce')} size="32" />
         {isDragging ? '파일을 끌어넣어 추가하기' : (innerFile?.name ?? '파일을 선택해주세요')}
       </div>
       <button


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- `OFFICIAL` 타입의 댓글을 달았을 때 바로 업데이트 되지 않는 현상 수정
- `OFFICIAL` 타입의 댓글이 최신순으로 표시되지 않는 현상 수정
- `OFFICIAL` 타입의 댓글이 수정, 삭제 후 바로 반영되지 않는 현상 수정(* 삭제는 백엔드 버그로 반영 X)

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..

## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
