### PR TITLE
fix(human-rights): `useSearchPosts`, `useGetUserInfo` 쿼리 키에 액세스 토큰 추가

### DIFF
--- a/src/pages/human-rights/hooks/query/useGetUserInfo.ts
+++ b/src/pages/human-rights/hooks/query/useGetUserInfo.ts
@@ -23,7 +23,8 @@ export interface GetUserInfoOptions {
 }
 
 export function useGetUserInfo({ queryOptions }: GetUserInfoOptions = {}) {
-  const queryKey = ['getUserInfo'];
+  const accessToken = localStorage.getItem('accessToken');
+  const queryKey = ['getUserInfo', accessToken];
   const config: AxiosRequestConfig = {
     url: `/users/user-info`,
     method: 'get',

--- a/src/pages/human-rights/hooks/query/useSearchPosts.ts
+++ b/src/pages/human-rights/hooks/query/useSearchPosts.ts
@@ -43,7 +43,8 @@ export function useSearchPosts<TRaw, TData = TRaw>({
   zodSchema,
   queryOptions,
 }: SearchPostsOptions<TRaw, TData>) {
-  const queryKey = ['searchPosts', boardCode, category, q, take, page];
+  const accessToken = localStorage.getItem('accessToken');
+  const queryKey = ['searchPosts', boardCode, accessToken, category, q, take, page];
   const config: AxiosRequestConfig = {
     url: `/board/${boardCode}/posts/search`,
     method: 'get',


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

`useSearchPosts`, `useGetUserInfo` 쿼리 키에 액세스 토큰을 추가하여 로그인/아웃 시에도 정상적으로 게시글 목록 및 사용자 정보가 표시되도록 하였습니다.

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..

## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
