### PR TITLE
fix: categoryName 필드 category 필드명으로 변경

### DIFF
--- a/src/pages/audit/auditPatch/hook/useAuditPatch.ts
+++ b/src/pages/audit/auditPatch/hook/useAuditPatch.ts
@@ -25,7 +25,7 @@ export function useAuditPatch() {
   const [thumbnailImage, setThumbnailImage] = useState<string>(imageList[0] ?? '');
 
   const [title, setTitle] = useState<string>(postDetail?.title ?? '');
-  const [category, setCategory] = useState<string>(postDetail?.categoryName ?? '');
+  const [category, setCategory] = useState<string>(postDetail?.category ?? '');
   const [content, setContent] = useState<string>(postDetail?.content ?? '');
   const [deletedFiles, setDeletedFiles] = useState<string[]>([]);
   const [newFiles, setNewFiles] = useState<File[]>([]);

--- a/src/pages/lost-article/patch/hook/useLostPatch.ts
+++ b/src/pages/lost-article/patch/hook/useLostPatch.ts
@@ -13,7 +13,7 @@ export function useLostPatch() {
   const postDetail = resp?.data.postDetailResDto;
 
   const [title, setTitle] = useState<string>(postDetail?.title ?? '');
-  const [category, setCategory] = useState<string>(postDetail?.categoryName ?? '');
+  const [category, setCategory] = useState<string>(postDetail?.category ?? '');
   const [content, setContent] = useState<string>(postDetail?.content ?? '');
   const imageList =
     postDetail?.fileResponseList?.filter((file) => file.fileType === 'images').map((file) => file.fileUrl) || [];

--- a/src/pages/partnership/partnershipPatch/hook/usePartnershipPatch.ts
+++ b/src/pages/partnership/partnershipPatch/hook/usePartnershipPatch.ts
@@ -26,7 +26,7 @@ export function usePartnershipPatch() {
   const [thumbnailImage, setThumbnailImage] = useState<string>(imageList[0] ?? '');
 
   const [title, setTitle] = useState<string>(postDetail?.title ?? '');
-  const [category, setCategory] = useState<string>(postDetail?.categoryName ?? '');
+  const [category, setCategory] = useState<string>(postDetail?.category ?? '');
   const [content, setContent] = useState<string>(postDetail?.content ?? '');
   const [deletedFiles, setDeletedFiles] = useState<string[]>([]);
   const [newFiles, setNewFiles] = useState<File[]>([]);

--- a/src/pages/petition-notice/[id]/containers/PostPetitionDetailPostSection.tsx
+++ b/src/pages/petition-notice/[id]/containers/PostPetitionDetailPostSection.tsx
@@ -164,7 +164,7 @@ export function PostPetitionDetailPostSection() {
           <div className="mb-[25px] mt-[182px] px-[200px] xs:px-[35px] sm:px-[35px] md:px-[70px] lg:px-[70px]">
             <Breadcrumb items={breadcrumbItems} />
             <PostHead
-              title={`[${data?.data.postDetailResDto.categoryName}] ${data?.data.postDetailResDto.title}`}
+              title={`[${data?.data.postDetailResDto.category}] ${data?.data.postDetailResDto.title}`}
               writer={
                 data?.data.postDetailResDto.studentId === null
                   ? data.data.postDetailResDto.authorName
@@ -190,7 +190,7 @@ export function PostPetitionDetailPostSection() {
                 </div>
               </div>
               <div className="xs:hidden sm:hidden md:hidden">
-                <StateTag current={data?.data.postDetailResDto.categoryName || null} />
+                <StateTag current={data?.data.postDetailResDto.category || null} />
               </div>
             </div>
             <div className="mt-[60px] flex-col">

--- a/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
+++ b/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
@@ -128,7 +128,7 @@ export function PetitionNoticeEditorSection() {
       try {
         const check = window.confirm('편집하시겠습니까?');
         if (check) {
-          const old_c = parsedContent.data.postDetailResDto.content;
+          const old_c = parsedContent.postDetailResDto.content;
           const new_c = patch_posts.posts.content;
 
           const removedImg = compareImgTags(JSON.parse(old_c), JSON.parse(new_c));

--- a/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
+++ b/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
@@ -115,7 +115,7 @@ export function PetitionNoticeEditorSection() {
       const postFileList = imageId ? imageId : [];
       const patch_posts = {
         boardCode: '청원게시판',
-        postId: Number(parsedContent.data.postDetailResDto.postId),
+        postId: Number(parsedContent.postDetailResDto.postId),
         posts: {
           title: title,
           content: JSON.stringify(content),

--- a/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
+++ b/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
@@ -28,7 +28,7 @@ export function PetitionNoticeEditorSection() {
   const navigate = useNavigate();
 
   const oldContent = localStorage.getItem('oldContent')!;
-  const parsedContent = JSON.parse(oldContent) as GetBoardDetailResponse;
+  const parsedContent = JSON.parse(oldContent) as GetBoardDetailResponse['data'];
 
   useEffect(() => {
     if (parsedContent) {

--- a/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
+++ b/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
@@ -14,7 +14,7 @@ import { usePostBoardPosts } from '@/hooks/api/post/usePostBoardPosts';
 import { GUIDE_LINE } from '../components/GuideLine';
 import { useDelBoardFiles } from '@/hooks/api/del/useDelBoardFiles';
 import { HookMap } from '@toast-ui/editor';
-
+import { GetBoardDetailResponse } from '@/types/apis/get';
 
 export function PetitionNoticeEditorSection() {
   const titleRef = useRef<HTMLInputElement>(null);
@@ -28,19 +28,19 @@ export function PetitionNoticeEditorSection() {
   const navigate = useNavigate();
 
   const oldContent = localStorage.getItem('oldContent')!;
-  const parsedContent = JSON.parse(oldContent);
+  const parsedContent = JSON.parse(oldContent) as GetBoardDetailResponse;
 
   useEffect(() => {
     if (parsedContent) {
-      const postDetailResDto = parsedContent.postDetailResDto;
+      const postDetailResDto = parsedContent.data.postDetailResDto;
       setInitialTitle(postDetailResDto.title);
       setInitialContent(JSON.parse(postDetailResDto.content));
-      setInitialCategoryName(postDetailResDto.categoryName);
+      setInitialCategoryName(postDetailResDto.category);
       setIsEditing(true);
     }
 
     setLoading(false);
-  }, []);
+  }, [parsedContent]);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length <= 50) {
@@ -115,7 +115,7 @@ export function PetitionNoticeEditorSection() {
       const postFileList = imageId ? imageId : [];
       const patch_posts = {
         boardCode: '청원게시판',
-        postId: Number(parsedContent.postDetailResDto.postId),
+        postId: Number(parsedContent.data.postDetailResDto.postId),
         posts: {
           title: title,
           content: JSON.stringify(content),
@@ -128,7 +128,7 @@ export function PetitionNoticeEditorSection() {
       try {
         const check = window.confirm('편집하시겠습니까?');
         if (check) {
-          const old_c = parsedContent.postDetailResDto.content;
+          const old_c = parsedContent.data.postDetailResDto.content;
           const new_c = patch_posts.posts.content;
 
           const removedImg = compareImgTags(JSON.parse(old_c), JSON.parse(new_c));

--- a/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
+++ b/src/pages/petition-notice/edit/containers/PetitionNoticeEditorSection.tsx
@@ -32,7 +32,7 @@ export function PetitionNoticeEditorSection() {
 
   useEffect(() => {
     if (parsedContent) {
-      const postDetailResDto = parsedContent.data.postDetailResDto;
+      const postDetailResDto = parsedContent.postDetailResDto;
       setInitialTitle(postDetailResDto.title);
       setInitialContent(JSON.parse(postDetailResDto.content));
       setInitialCategoryName(postDetailResDto.category);

--- a/src/types/apis/get/index.tsx
+++ b/src/types/apis/get/index.tsx
@@ -39,7 +39,7 @@ export interface FileResponse {
 
 export interface PostDetailResDto {
   postId: number;
-  categoryName: string;
+  category: string;
   authorName: string;
   allowedAuthorities: string[];
   title: string;


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #361

### 기존 코드에 영향을 미치지 않는 변경사항

### 기존 코드에 영향을 미치는 변경사항

PostDetailResDto 타입 중 categoryName -> category 로 변경
PostPetitionDetailPostSection.tsx 타입 변경 적용
useAuditPatch.ts useLostPatch.ts usePartenership.ts 타입 변경 적용

### 버그 픽스

### ✚ 피그마

### ✚ 관련 문서

## 2️⃣ 리뷰어에게..

## 3️⃣ 추후 작업할 내용

## 4️⃣ 체크리스트

- [ ] `main` 브랜치의 최신 코드를 `pull` 받았나요?
