### PR TITLE
fix: 파일 업로드 요청 시 자료집게시판의 boardCode 값은 data로 설정

### DIFF
--- a/src/components/BoardNew/edit/FileInput.tsx
+++ b/src/components/BoardNew/edit/FileInput.tsx
@@ -159,15 +159,15 @@ export const FileInput = forwardRef<HTMLInputElement, FileItemProps>(function (
             (innerFile?.name ?? '파일을 선택해주세요')
           )}
         </span>
-        {innerFile && categories && (
-          <FilterDropDown
-            className="flex h-[48px] w-[354px] justify-center rounded-[12px] border-gray-500 text-[19px] font-medium xs:w-[257px] sm:w-[187px]"
-            defaultValue="파일종류 선택"
-            optionValue={categories || []}
-            onValueChange={categoryChangeHandler}
-          />
-        )}
       </div>
+      {innerFile && categories && (
+        <FilterDropDown
+          className="flex h-[64px] w-[354px] justify-center rounded-[12px] border-gray-500 text-[19px] font-medium xs:w-[257px] sm:w-[187px]"
+          defaultValue="파일종류 선택"
+          optionValue={categories || []}
+          onValueChange={categoryChangeHandler}
+        />
+      )}
       <button
         className="p-4"
         onClick={() => (innerFile ? innerRef.current != null && clearFile() : innerRef.current?.showPicker())}

--- a/src/hooks/new/mutations/useUploadFiles.ts
+++ b/src/hooks/new/mutations/useUploadFiles.ts
@@ -42,7 +42,7 @@ export function useUploadFiles({ boardCode, mutationOptions }: UseUploadFilesOpt
     return (
       await clientAuth<ApiResponse<UploadFilesResponse>>({
         method: 'post',
-        url: `/board/${boardCode === '자료집게시판' ? 'data' : boardCode}/files${fileType ? `/${fileType}` : ''}`,
+        url: `/board/${boardCode}/files${fileType ? `/${fileType}` : ''}`,
         data: formData,
         headers: {
           'Content-Type': 'multipart/form-data',

--- a/src/pages/data/queries.ts
+++ b/src/pages/data/queries.ts
@@ -25,7 +25,7 @@ export function useDeleteDataPost({ mutationOptions }: Omit<UseDeletePostOptions
   return useDeletePost({ boardCode: BOARD_CODE, mutationOptions });
 }
 
-// 자료집 파일 업로드
+// 자료집 파일 업로드 (자료집의 경우에만 boardCode에 게시판명이 아닌 'data'가 boardCode에 대응됨)
 export function useUploadDataFiles({ mutationOptions }: Omit<UseUploadFilesOptions, 'boardCode'> = {}) {
   return useUploadFiles({ boardCode: 'data', mutationOptions });
 }

--- a/src/pages/data/queries.ts
+++ b/src/pages/data/queries.ts
@@ -27,5 +27,5 @@ export function useDeleteDataPost({ mutationOptions }: Omit<UseDeletePostOptions
 
 // 자료집 파일 업로드
 export function useUploadDataFiles({ mutationOptions }: Omit<UseUploadFilesOptions, 'boardCode'> = {}) {
-  return useUploadFiles({ boardCode: BOARD_CODE, mutationOptions });
+  return useUploadFiles({ boardCode: 'data', mutationOptions });
 }


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #408 

파일 업로드 요청 시 자료집게시판의 경우 boardCode 값을 data로 설정해줬습니다.

## 2️⃣ 추후 작업할 내용
자료집의 FileInput 스타일 변경

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
