### PR TITLE
feat: fileUrl에서 확장자명 추출 후 fileType 뒤에 삽입 #439

### DIFF
--- a/src/components/File/FileDownButton.tsx
+++ b/src/components/File/FileDownButton.tsx
@@ -5,6 +5,9 @@ import { buttonVariants } from '@/components/ui/button.tsx';
 // 자료집 '/data'에 쓰이는 FileDownButton입니다.
 
 export default function FileDownButton({ file, className }: { file: FileResponse; className?: string }) {
+  // fileUrl에서 확장자명을 추출한 후 대문자로 변경
+  const lastDotIndex = file.fileUrl.lastIndexOf('.');
+  const fileExtension = lastDotIndex !== -1 ? file.fileUrl.substring(lastDotIndex + 1) : '';
   return (
     <a
       className={cn(
@@ -17,7 +20,7 @@ export default function FileDownButton({ file, className }: { file: FileResponse
       href={file.fileUrl}
       download={file.fileName}
     >
-      {file.fileType}
+      {`${file.fileType} ${fileExtension.toUpperCase()}`}
     </a>
   );
 }


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #439 

결과물 이미지
![image](https://github.com/user-attachments/assets/5a5e2ef0-f34e-49ed-931b-4db0b31b128a)

```
  **// fileUrl에서 확장자명을 추출한 후 대문자로 변경
  const lastDotIndex = file.fileUrl.lastIndexOf('.');
  const fileExtension = lastDotIndex !== -1 ? file.fileUrl.substring(lastDotIndex + 1) : '';**
  return (
    <a
      className={cn(
        buttonVariants(),
        'h-[31px] w-[143px] rounded-[9px] bg-gray-200 text-[16px] font-medium text-gray-600',
        'cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap px-2 hover:text-white',
        className
      )}
      title={file.fileType}
      href={file.fileUrl}
      download={file.fileName}
    >
      **{`${file.fileType} ${fileExtension.toUpperCase()}`}**
    </a>
  );
```

확장자명 앞에만 .이 있는 게 아니라서 마지막 .을 기준으로 문자열 끝까지를 확장자명으로 추출했습니다.
디자인에는 확장자명을 대문자로 표현해서 toUpperCase()로 대문자화 했습니다.

더 좋은 방법 있으면 말씀해주세요 💀 

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
