### PR TITLE
hotfix: navigator 컴포넌트와 header 컴포넌트 z-index 조정

### DIFF
--- a/src/containers/common/Header/Header.tsx
+++ b/src/containers/common/Header/Header.tsx
@@ -29,7 +29,7 @@ export function Header({ state = State.Onboarding, onLogout = () => {} }: Header
   return (
     <div
       className={cn(
-        'fixed top-0 z-10 flex h-[60px] w-[100vw] justify-start xs:h-[50px] sm:h-[50px] md:h-[50px] xl:justify-between xxl:justify-between',
+        'fixed top-0 z-50 flex h-[60px] w-[100vw] justify-start xs:h-[50px] sm:h-[50px] md:h-[50px] xl:justify-between xxl:justify-between',
         styles.bgColor
       )}
     >


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #479 

Header가 소개페이지 Navigator 컴포넌트 밑으로 가는 현상 때문에 z-index 값 조정했습니다

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
