### PR TITLE
hotfix : 총학과 중운위 댓글 작성 불가 문제, 스크린 넓이 1440px부터 로그인 로그아웃 제대로 반영 안되는 문제

### DIFF
--- a/src/pages/main/page.tsx
+++ b/src/pages/main/page.tsx
@@ -13,9 +13,6 @@ import { NoticeResponse } from '../notice/types';
 import { MAIN_PENDING } from './const';
 import QnaSection from './containers/QnaSection';
 import { useResize } from '@/hooks/useResize';
-import { Header } from '@/containers/common/Header/Header';
-import { Footer } from '@/containers/common/Footer/Footer';
-import { State } from '@/containers/common/Header/const/state';
 
 export function MainPage() {
   const boardCode = '서비스공지사항';
@@ -27,7 +24,6 @@ export function MainPage() {
 
   return (
     <>
-      <Header state={State.Login} />
       <main className="h-screen snap-y snap-mandatory overflow-y-scroll">
         {isLoading ? (
           <div className="flex items-center justify-center">
@@ -64,7 +60,6 @@ export function MainPage() {
         </div>
       </main>
       <Spacing size={202} direction="vertical" />
-      <Footer />
     </>
   );
 }

--- a/src/pages/mypage/service-notice/component/ServiceNoticeTab.tsx
+++ b/src/pages/mypage/service-notice/component/ServiceNoticeTab.tsx
@@ -58,7 +58,7 @@ export function ServiceNoticeTab({ isEmergency, title, postId }: ServiceNoticeTa
       {!hasCookie && open ? (
         <div
           className={cn(
-            'fixed top-[60px] z-50 flex h-[64px] w-full items-center justify-center gap-[8px] border-b-[1px] border-[#9CA3AF] bg-white pl-[10px] pr-[10px] xs:top-[48px] xs:h-[48px] sm:top-[50px] sm:h-[48px] md:top-[50px]',
+            'fixed top-[60px] z-40 flex h-[64px] w-full items-center justify-center gap-[8px] border-b-[1px] border-[#9CA3AF] bg-white pl-[10px] pr-[10px] xs:top-[48px] xs:h-[48px] sm:top-[50px] sm:h-[48px] md:top-[50px]',
             fadeOut ? 'animate-fadeout' : 'animate-fadein'
           )}
           onAnimationEnd={handleAnimationEnd}

--- a/src/pages/qna-notice/[id]/page.tsx
+++ b/src/pages/qna-notice/[id]/page.tsx
@@ -53,7 +53,7 @@ export default function QnaDetailPage() {
     isLoading: isCommentsLoading,
     isError: isCommentsError,
     error: commentsError,
-  } = useGetComments<QnaComment>({ postId, type: '최신순' });
+  } = useGetComments<QnaComment>({ postId, type: '최신순', queryOptions: { refetchOnMount: 'always', staleTime: 0 } });
 
   // 게시글 삭제
   const { mutate: deleteDetail, isPending: isDeleteDetailPending } = useDeleteQnaDetail();

--- a/src/pages/router.tsx
+++ b/src/pages/router.tsx
@@ -4,8 +4,8 @@ import * as i from './index.ts';
 export function MainRouter() {
   return (
     <Routes>
-      <Route path="/" element={<i.MainPage />} />
       <Route path="/" element={<i.Layout />}>
+        <Route path="/" element={<i.MainPage />} />
         {/* 1. 소개 */}
         <Route path="/intro" element={<i.IntroPage />} />
         <Route path="/intro/edit" element={<i.IntroEditPage />} />


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #486 
- **Header에 애니메이션을 적용하면서 생성했던 더미 Header로 인해 발생한 문제였기에 이전 코드로 변경하여 오류 수정**
    - src/pages/router.tsx => MainPage에 대한 Route 태그를 Layout에 대한 Route 태그 내부로 이동
    - src/pages/main/page.tsx => 더미 Header와 Footer 제거
- **긴급공지가 Navigation의 드롭다운을 가리는 문제 해결**
    - src/pages/mypage/service-notice/component/ServiceNoticeTap.tsx 긴급 공지에 대한 z-index 값을 변경하여 Navigation의 드롭다운을 가리지 않도록 수정
- **렌더링 시마다 댓글 데이터를 리페칭하지 않아 권한 업데이트가 안되어 댓글 작성창이 안뜨는 문제 해결**
    - src/pages/qna-notice/[id]/page.tsx => 렌더링 시마다 댓글 데이터 리페칭
    ```ts
      const {
        data: comments,
        isLoading: isCommentsLoading,
        isError: isCommentsError,
        error: commentsError,
      } = useGetComments<QnaComment>({ postId, type: '최신순', queryOptions: { refetchOnMount: 'always', staleTime: 0 } });
    ```

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
