### PR TITLE
fix: 질의응답게시판 QA 적용 (#482)

### DIFF
--- a/src/pages/qna-notice/[id]/page.tsx
+++ b/src/pages/qna-notice/[id]/page.tsx
@@ -18,6 +18,8 @@ import { useDeleteQnaReply } from '../hooks/useDeleteQnaReplyComment';
 import { usePatchComment } from '@/hooks/new/mutations/usePatchComment';
 import { useGetComments } from '@/hooks/new/query/useGetComments';
 
+const boardCode = '질의응답게시판';
+
 function PageSkeleton() {
   return (
     <article className="mb-20 mt-[120px]">
@@ -43,7 +45,7 @@ export default function QnaDetailPage() {
     navigate('/');
   }
 
-  // 상세 게시글 조화 & 댓글 조회
+  // 상세 게시글 조회 & 댓글 조회
   const { data, isLoading, isError, error } = useGetQnaDetail({ postId });
 
   const {
@@ -80,7 +82,7 @@ export default function QnaDetailPage() {
             queryKey: ['getComments', postId],
           });
           await queryClient.invalidateQueries({
-            queryKey: ['getPost', postId],
+            queryKey: ['getPost', boardCode, postId],
           });
         },
       }
@@ -99,7 +101,7 @@ export default function QnaDetailPage() {
             queryKey: ['getComments', postId],
           });
           queryClient.invalidateQueries({
-            queryKey: ['getPost', postId],
+            queryKey: ['getPost', boardCode, postId],
           });
         },
       }
@@ -115,7 +117,7 @@ export default function QnaDetailPage() {
       {
         onSuccess: () => {
           queryClient.invalidateQueries({ queryKey: ['getComments', postId] });
-          queryClient.invalidateQueries({ queryKey: ['getPost', postId] });
+          queryClient.invalidateQueries({ queryKey: ['getPost', boardCode, postId] });
         },
       }
     );
@@ -214,7 +216,8 @@ export default function QnaDetailPage() {
                   commentType={comment.commentType}
                   lastEditedAt={comment.lastEditedAt ? convertToDate(comment.lastEditedAt) : undefined}
                   editable={comment.isAuthor}
-                  deletable={comment.commentType !== 'OFFICIAL' && (comment.isAuthor || commentDeletable)}
+                  deletable={comment.isAuthor || commentDeletable}
+                  deleted={comment.isDeleted ?? false}
                   onDelete={() => handleDeleteComment(comment.id)}
                   onEdit={(content) => handlePatchComment(comment.id, content)}
                 >

--- a/src/pages/qna-notice/[id]/types.ts
+++ b/src/pages/qna-notice/[id]/types.ts
@@ -23,6 +23,7 @@ export interface QnaOfficialComment {
   createdAt: string;
   lastEditedAt: string | null;
   isAuthor: boolean;
+  isDeleted: boolean;
 }
 
 // API 응답의 data 내부 구조를 나타내는 타입

--- a/src/pages/qna-notice/edit/page.tsx
+++ b/src/pages/qna-notice/edit/page.tsx
@@ -175,7 +175,7 @@ export default function QnaEditPage() {
       <hr className="bg-[#E7E7E7]" />
       <Container>
         {!isEdit && (
-          <section className="mb-[17px] flex justify-between">
+          <section className="mb-4 flex justify-between xs:flex-col sm:flex-col">
             {/* 질문 대상 선택 드롭다운 */}
             <select
               {...register('qnaMemberCode')}
@@ -188,6 +188,7 @@ export default function QnaEditPage() {
               border border-gray-600  
               bg-[url(/image/arrow-down.svg)] bg-[position:calc(100%-3rem)_center] bg-no-repeat
               text-center text-gray-800
+              xs:mb-3 xs:w-auto sm:mb-3 sm:w-auto
             "
               disabled={isEdit}
             >
@@ -211,6 +212,7 @@ export default function QnaEditPage() {
             border border-gray-600  
             bg-[url(/image/arrow-down.svg)] bg-[position:calc(100%-3rem)_center] bg-no-repeat
             text-center text-gray-800
+            xs:w-auto sm:w-auto
             "
               disabled={selectedMember === undefined || isEdit}
             >

--- a/src/pages/qna-notice/page.tsx
+++ b/src/pages/qna-notice/page.tsx
@@ -147,7 +147,11 @@ export function QnApage() {
   }
 
   function navigateToWrite() {
-    navigate('/qna/edit');
+    if (isLogin) {
+      navigate('/qna/edit');
+    } else {
+      navigate('/register');
+    }
   }
 
   return (


### PR DESCRIPTION
- resolved #448

- 질의응답게시판 페이지
    - 로그인 하지 않은 경우 글쓰기 버튼 표시
    - 비로그인 사용자가 글쓰기 버튼 클릭 시 로그인 페이지로 이동
    - 로그인 사용자가 글쓰기 버튼 클릭 시 질의응답 게시글 작성 페이지로 이동
- 질의응답게시판 작성 페이지
    - 질문 대상 선택 및 세부 대상 선택 select 모바일 화면에서 스타일 깨지는 문제 수정
- 질의응답게시판 상세 페이지
- 자치기구 게시글 작성 및 수정 시 이용하는 queryClient 로직 상세 게시글 데이터에 대한 쿼리키에 누락된 boardCode 추가

백엔드 작업이 완료됐다고 전달 받았으나 아직 적용이 안된 상태

-> 오피셜 댓글에 대한 isDelete 속성 추가 후 로컬에서 테스트 완료

- [x] 질의응답게시판 상세게시글 작성 페이지, 모바일 화면에서 글쓰기 대상 선택 css 깨짐
- [x] 질의응답게시판 상세게시글 페이지, 자치기구 댓글 삭제가 가능하도록 변경
- [x] 질의응답게시판 리스트 페이지, 비로그인 사용자에게 글쓰기 버튼이 보이게 하고 클릭 시 로그인 화면으로 이동

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?

---------

## 1️⃣ 작업 내용 Summary

- resolved #(issue_num)

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [ ] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
