### PR TITLE
chore: 질의응답게시판 글쓰기 버튼 클릭시 시범운영 alert창 띄우기

### DIFF
--- a/src/pages/qna-notice/page.tsx
+++ b/src/pages/qna-notice/page.tsx
@@ -147,11 +147,13 @@ export function QnApage() {
   }
 
   function navigateToWrite() {
-    if (isLogin) {
-      navigate('/qna/edit');
-    } else {
-      navigate('/register');
-    }
+    alert('시범운영 기간이 종료되었습니다. 곧 오픈 예정이니 다음에 이용해주세요');
+
+    // if (isLogin) {
+    //   navigate('/qna/edit');
+    // } else {
+    //   navigate('/register');
+    // }
   }
 
   return (

--- a/src/pages/qna-notice/page.tsx
+++ b/src/pages/qna-notice/page.tsx
@@ -2,7 +2,7 @@ import { HeadLayout } from '@/template/HeadLayout';
 import { BodyLayout } from '@/template/BodyLayout';
 import { BoardSelector } from '@/components/Board/BoardSelector';
 import { PostContent } from '@/components/PostContent/PostContent';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { QnaPostParams, useGetQnaList } from './hooks/useGetQnaList';
 import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -77,7 +77,7 @@ function PageSkeleton() {
 }
 
 export function QnApage() {
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const page = parseInt(searchParams.get('page') ?? '1') || 1;


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #492 

질의응답게시판 글쓰기 버튼 클릭시
시범운영 기간이 종료되었습니다. 곧 오픈 예정이니 다음에 이용해주세요
문구가 표시된 alert 창이 뜨도록 수정했습니다.

```ts
  function navigateToWrite() {
    alert('시범운영 기간이 종료되었습니다. 곧 오픈 예정이니 다음에 이용해주세요');

    // if (isLogin) {
    //   navigate('/qna/edit');
    // } else {
    //   navigate('/register');
    // }
  }

```

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
