### PR TITLE
fix: 플로팅섹션 조금 아래로 #527

### DIFF
--- a/src/pages/main/containers/FloatingButtons.tsx
+++ b/src/pages/main/containers/FloatingButtons.tsx
@@ -28,7 +28,7 @@ export function FloatingButtons() {
 
   return (
     <div
-      className={`fixed right-4 top-24 z-30 transition-all duration-500 md:right-10${
+      className={`fixed right-4 top-20 z-30 transition-all duration-500 md:right-10${
         isVisible ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-[-20px] opacity-0'
       }`}
     >

--- a/src/pages/main/containers/FloatingButtons.tsx
+++ b/src/pages/main/containers/FloatingButtons.tsx
@@ -6,7 +6,7 @@ import KakaoIcon from '@/components/SvgIcon/KakaoIcon';
 import InstaIcon from '@/components/SvgIcon/InstaIcon';
 import ChannelTalkIcon from '@/components/SvgIcon/ChannelTalkIcon';
 
-export function CounselBtn() {
+export function FloatingButtons() {
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
@@ -28,7 +28,7 @@ export function CounselBtn() {
 
   return (
     <div
-      className={`fixed right-4 top-20 z-50 transition-all duration-500 md:right-10${
+      className={`fixed right-4 top-32 z-50 transition-all duration-500 md:right-10${
         isVisible ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-[-20px] opacity-0'
       }`}
     >

--- a/src/pages/main/containers/FloatingButtons.tsx
+++ b/src/pages/main/containers/FloatingButtons.tsx
@@ -28,7 +28,7 @@ export function FloatingButtons() {
 
   return (
     <div
-      className={`fixed right-4 top-32 z-50 transition-all duration-500 md:right-10${
+      className={`fixed right-4 top-24 z-30 transition-all duration-500 md:right-10${
         isVisible ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-[-20px] opacity-0'
       }`}
     >

--- a/src/pages/main/page.tsx
+++ b/src/pages/main/page.tsx
@@ -6,7 +6,7 @@ import { Spacing } from '@/components/Spacing';
 // import PetitionSection from './containers/PetitionSection';
 // import LostArticleSection from './containers/LostArticleSection';
 import CampusMapSection from './containers/CampusMapSection';
-import { CounselBtn } from './containers/CounselBtn';
+import { FloatingButtons } from './containers/FloatingButtons';
 import { ServiceNoticeTab } from '../mypage/service-notice/component/ServiceNoticeTab';
 import { useGetBoardPosts } from '@/hooks/api/get/useGetBoardPosts';
 import { NoticeResponse } from '../notice/types';
@@ -42,7 +42,7 @@ export function MainPage() {
 
       <MainCarousel className="h-screen" id={MAIN_PENDING} />
       <MainScheduleSection id={MAIN_PENDING} />
-      <CounselBtn />
+      <FloatingButtons />
 
       <div className="snap-start px-[15px] md:px-[3.125rem] lg:px-[12.5rem]">
         <Spacing size={86} direction="vertical" />


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #527 

1. Counsel이라는 뜻이 적절하지않은 거 같아서, FloatingButtons라고 바꾸었습니다.
2. FloatingButtons의 z-index를 ServiceNoticeTab의 아래로 변경했습니다.

![image](https://github.com/user-attachments/assets/6b488135-777b-452c-bb0d-7fdd45db6b37)

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
