### PR TITLE
fix: passu 리다이렉트 자치기구 로그인 기능 추가

### DIFF
--- a/src/pages/layout/registerLayout.tsx
+++ b/src/pages/layout/registerLayout.tsx
@@ -1,32 +1,11 @@
-import { useEffect } from 'react';
-import { Outlet, useNavigate } from 'react-router';
+import { Outlet } from 'react-router';
 import { Header } from '@/containers/common/Header/Header';
 import { State } from '@/containers/common/Header/const/state';
-import { LoginState } from '@/atoms/atom';
-import { useAtom } from 'jotai';
 
 export function RegisterLayout() {
-  const [loginState, setLoginState] = useAtom(LoginState);
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    if (token) {
-      setLoginState(true);
-    } else {
-      setLoginState(false);
-    }
-  }, [setLoginState]);
-
-  const handleLogout = () => {
-    localStorage.clear();
-    setLoginState(false);
-    navigate('/');
-  };
-
   return (
     <div className="flex min-h-screen flex-col">
-      <Header state={loginState ? State.Login : State.Logout} onLogout={handleLogout} />
+      <Header state={State.Onboarding} />
       <main className="grow">
         <Outlet />
       </main>

--- a/src/pages/register/step/scouncil/page.tsx
+++ b/src/pages/register/step/scouncil/page.tsx
@@ -34,22 +34,24 @@ export function GeneralLoginPage() {
 
   const formValues = watch();
 
-  // const redirectUrl = localStorage.getItem('redirectUrl');
+  const redirectUrl = localStorage.getItem('redirectUrl');
+  const accessToken = localStorage.getItem('accessToken');
 
   useEffect(() => {
     setIsButtonDisabled(!isValid);
   }, [isValid]);
 
-  const setDataInLocalStorage = (data: { groupCodeList: string[]; memberName: string }) => {
+  const setDataInLocalStorage = (data: { groupCodeList: string[]; memberName: string; accessToken: string }) => {
     localStorage.setItem('groupCodeList', JSON.stringify(data?.groupCodeList));
     localStorage.setItem('memberName', data?.memberName);
+    localStorage.setItem('accessToken', data?.accessToken);
   };
   const mutation = usePostLoginData({
     mutationOptions: {
       onSuccess: (data: PostScouncilLoginDataResponse) => {
-        navigate('/');
         setLoginState(true);
         setDataInLocalStorage(data);
+        navigate('/');
       },
       onError: () => {
         setScouncilError(true);
@@ -62,15 +64,14 @@ export function GeneralLoginPage() {
   });
 
   const onSubmit: SubmitHandler<FieldValues> = async () => {
-    //     // passu에서 자치기구 로그인 해야한다고 하면 주석 해제 아니면 주석 삭제
-    //     // if (redirectUrl !== null) {
-    //     //   const separator = redirectUrl.includes('?') ? '&' : '?';
-    //     //   const newRedirectUrl = `${redirectUrl}${separator}accessToken=${encodeURIComponent(accessToken)}`;
-    //     //   localStorage.removeItem('redirectUrl');
-    //     //   localStorage.removeItem('kakaoData');
-    //     //   window.location.href = newRedirectUrl;
-    //     //   return;
-    //     // }
+    if (redirectUrl !== null && accessToken !== null) {
+      const separator = redirectUrl.includes('?') ? '&' : '?';
+      const newRedirectUrl = `${redirectUrl}${separator}accessToken=${encodeURIComponent(accessToken)}`;
+      localStorage.removeItem('redirectUrl');
+      localStorage.removeItem('kakaoData');
+      window.location.href = newRedirectUrl;
+      return;
+    }
     mutation.mutate({
       accountId: formValues.accountId,
       password: formValues.password,


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #532 
Passu에서 넘어올 때 자치기구 로그인 성공 시 passu로 리다이렉트하는 부분을 각주 처리하였는데 이 부분 필요하여서 다시 추가해놓았습니다.
추가로 #526 로그인 성공 시 토큰 저장 로직 추가 pr이 누락되어서 그 부분도 추가하였습니다.

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
