### PR TITLE
refactor: ServiceNoticeTab Header와 벌어짐 해결

### DIFF
--- a/src/pages/mypage/service-notice/component/ServiceNoticeTab.tsx
+++ b/src/pages/mypage/service-notice/component/ServiceNoticeTab.tsx
@@ -58,12 +58,12 @@ export function ServiceNoticeTab({ isEmergency, title, postId }: ServiceNoticeTa
       {!hasCookie && open ? (
         <div
           className={cn(
-            'fixed top-[48px] z-40 flex h-[48px] w-full items-center justify-center gap-[8px] border-b-[1px] border-[#9CA3AF] bg-white pl-[10px] pr-[10px] sm:top-[50px] md:top-[60px] md:h-[64px]',
+            'fixed top-12 z-40 flex h-12 w-full items-center justify-center gap-4 border-y border-[#9CA3AF] bg-white px-8 xl:h-16 xl:top-16',
             fadeOut ? 'animate-fadeout' : 'animate-fadein'
           )}
           onAnimationEnd={handleAnimationEnd}
         >
-          <div className="flex cursor-pointer items-center justify-center gap-[8px]" onClick={handleTabClick}>
+          <div className="flex cursor-pointer items-center justify-center gap-4" onClick={handleTabClick}>
             {isEmergency ? (
               <Badge variant="emergency-old" className="relative right-0 top-0">
                 긴급
@@ -71,9 +71,9 @@ export function ServiceNoticeTab({ isEmergency, title, postId }: ServiceNoticeTa
             ) : (
               <div></div>
             )}
-            <div className="text-[12px] font-[700] md:text-[18px]">{title}</div>
+            <div className="text-[0.75rem] font-[700] md:text-[1.125rem]">{title}</div>
           </div>
-          <div className="absolute right-[20px] flex gap-[4px] text-[18px]" onClick={handleClose}>
+          <div className="absolute right-6 flex gap-2 text-[1.125rem]" onClick={handleClose}>
             {width >= 1080 ? <div className="text-[#9CA3AF]">하루동안 보지 않기</div> : null}
             {width >= 720 ? <img src={XdeleteImg} alt="삭제 버튼" className="cursor-pointer" /> : null}
           </div>

--- a/src/pages/mypage/service-notice/component/ServiceNoticeTab.tsx
+++ b/src/pages/mypage/service-notice/component/ServiceNoticeTab.tsx
@@ -58,7 +58,7 @@ export function ServiceNoticeTab({ isEmergency, title, postId }: ServiceNoticeTa
       {!hasCookie && open ? (
         <div
           className={cn(
-            'fixed top-12 z-40 flex h-12 w-full items-center justify-center gap-4 border-y border-[#9CA3AF] bg-white px-8 xl:h-16 xl:top-16',
+            'fixed top-12 z-40 flex h-12 w-full items-center justify-center gap-4 border-y border-[#9CA3AF] bg-white px-8 xl:top-16 xl:h-16',
             fadeOut ? 'animate-fadeout' : 'animate-fadein'
           )}
           onAnimationEnd={handleAnimationEnd}


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #534 

서비스공지사항 탭 헤더와 벌어지는 이슈 수정했습니다.

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `main` 브랜치의 최신 코드를 `pull` 받았나요?
