### PR TITLE
chore: Header 이전 홈페이지 제거

### DIFF
--- a/src/containers/common/Header/Header.tsx
+++ b/src/containers/common/Header/Header.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ui/navigation-menu';
 import { useTranslation } from 'react-i18next';
 import { getStyles } from '@/containers/common/Header/const/style';
-import { DATA_PATH, MENU_ITEMS, OLD_URL, QNA_PATH } from '@/containers/common/Header/const/pathData';
+import { DATA_PATH, MENU_ITEMS, QNA_PATH } from '@/containers/common/Header/const/pathData';
 import DropDownMenu from '@/containers/common/Header/component/DropDownMenu';
 
 interface HeaderProps {
@@ -127,22 +127,6 @@ export function Header({ state = State.Onboarding, onLogout = () => {} }: Header
                   )}
                 >
                   {t('header.자료집')}
-                </Link>
-              </NavigationMenuLink>
-            </NavigationMenuItem>
-
-            <NavigationMenuItem>
-              <NavigationMenuLink asChild>
-                <Link
-                  to={`${OLD_URL}`}
-                  className={cn(
-                    navigationMenuTriggerStyle(),
-                    'h-full bg-transparent px-7 text-foreground transition-colors hover:text-foreground',
-                    state !== State.Onboarding && 'xl:text-primary-foreground hover:xl:text-primary-foreground',
-                    textSize
-                  )}
-                >
-                  {t('header.이전 홈페이지')}
                 </Link>
               </NavigationMenuLink>
             </NavigationMenuItem>

--- a/src/containers/common/Header/component/HeaderSheet.tsx
+++ b/src/containers/common/Header/component/HeaderSheet.tsx
@@ -1,4 +1,4 @@
-import { DATA_PATH, MENU_ITEMS, OLD_URL } from '@/containers/common/Header/const/pathData';
+import { DATA_PATH, MENU_ITEMS } from '@/containers/common/Header/const/pathData';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Globe } from '@phosphor-icons/react';
 import { ReactNode, useEffect, useState } from 'react';
@@ -87,9 +87,6 @@ export function HeaderSheet({ trigger, state, onLogout }: HeaderSheetProps) {
           <Link className={cn(buttonVariants({ variant: 'sheet-item' }), 'px-0 py-7')} to={DATA_PATH}>
             {t('header.자료집')}
           </Link>
-          <a className={cn(buttonVariants({ variant: 'sheet-item' }), 'px-0 py-7')} target="_blank" href={OLD_URL}>
-            {t('header.이전 홈페이지')}
-          </a>
           {state === State.Login ? (
             // <Link className={cn(buttonVariants({ variant: 'sheet-item' }), 'px-0 py-7')} to="/mypage">
             //   {t('introduction.마이페이지')}

--- a/src/containers/common/Header/const/pathData.tsx
+++ b/src/containers/common/Header/const/pathData.tsx
@@ -53,6 +53,4 @@ export const DATA_PATH = '/data' as const; // 자료집 라우트 경로
 
 export const MYPAGE_PATH = `/my` as const; // 내정보 라우트 경로
 
-export const OLD_URL = `https://ssuketch60.cafe24.com/` as const; // 이전 홈페이지
-
 export const QNA_PATH = '/qna' as const; //


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #545 

이전 홈페이지 호스팅 중단에 따라 Header 레이아웃에서 '이전 홈페이지'를 삭제하고 관련 코드들을 정리했습니다.

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
