### PR TITLE
feat: 공지사항 이미지 업로드 시 고용량 제한 문구 추가

### DIFF
--- a/src/pages/notice/edit/component/ImageDropzone.tsx
+++ b/src/pages/notice/edit/component/ImageDropzone.tsx
@@ -3,12 +3,19 @@ import { Plus } from '@phosphor-icons/react';
 
 interface ImageDropzoneProps {
   onDrop: (acceptedFiles: File[]) => void;
+  onFileSizeError?: () => void;
 }
 
-export function ImageDropzone({ onDrop }: ImageDropzoneProps) {
+export function ImageDropzone({ onDrop, onFileSizeError }: ImageDropzoneProps) {
   const { getRootProps, getInputProps } = useDropzone({
     onDrop: (acceptedFiles) => {
       onDrop(acceptedFiles);
+    },
+    onDropRejected: (fileRejections) => {
+      const oversizedFiles = fileRejections.filter((rejection) => rejection.file.size > 10 * 1024 * 1024);
+      if (oversizedFiles.length > 0 && onFileSizeError) {
+        onFileSizeError();
+      }
     },
     accept: {
       'image/jpeg': ['.jpeg', '.jpg'],
@@ -16,6 +23,7 @@ export function ImageDropzone({ onDrop }: ImageDropzoneProps) {
       'image/gif': ['.gif'],
     },
     multiple: true,
+    maxSize: 10 * 1024 * 1024,
   });
 
   return (

--- a/src/pages/notice/edit/container/noticeEditImageSection.tsx
+++ b/src/pages/notice/edit/container/noticeEditImageSection.tsx
@@ -1,7 +1,7 @@
 import { ImageDropzone } from '../component/ImageDropzone';
 import { ImagePreview } from '../component/ImagePreview';
 import { useImageManager } from '../hook/useImageManager';
-import { useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 
 interface NoticeEditImageSectionProps {
   onImagesChange: (images: File[]) => void;
@@ -9,6 +9,16 @@ interface NoticeEditImageSectionProps {
 
 export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectionProps): JSX.Element {
   const { images, addImage, removeImage, getValidImages } = useImageManager();
+  const [sizeError, setSizeError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (sizeError) {
+      const timer = setTimeout(() => {
+        setSizeError(false);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [sizeError]);
 
   useEffect(() => {
     onImagesChange(getValidImages());
@@ -24,7 +34,7 @@ export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectio
   return (
     <div className="px-[30px] xl:px-[200px]">
       <div className="mt-[12px] flex h-[270px] w-full flex-row items-center justify-start gap-4 overflow-x-auto whitespace-nowrap rounded-xs border-[0.125rem] border-gray-300 p-4">
-        <ImageDropzone onDrop={handleImageAdd} />
+        <ImageDropzone onDrop={handleImageAdd} onFileSizeError={() => setSizeError(true)} />
         <div className="flex max-w-full flex-row gap-4">
           {images.map((imageItem, index) => (
             <ImagePreview
@@ -36,6 +46,9 @@ export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectio
           ))}
         </div>
       </div>
+      {sizeError && (
+        <p className="my-1 ml-1 font-medium text-red-500">10MB를 초과하는 이미지는 업로드할 수 없습니다.</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #566

10MB 넘는 이미지 첨부 시 이렇게 에러 문구 뜨게 했습니다. 사라지는 조건이 애매해 3초 후 없어지게 했습니다.
![image](https://github.com/user-attachments/assets/f6552264-faad-47f5-94a0-380a004393b6)

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
