### PR TITLE
feat: 이미지 파일에 Browser-image-compression 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@tanstack/react-query": "^5.71.10",
     "@toast-ui/react-editor": "^3.2.3",
     "axios": "^1.8.4",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/src/pages/main/containers/NoticeSection.tsx
+++ b/src/pages/main/containers/NoticeSection.tsx
@@ -2,7 +2,7 @@ import { Spacing } from '@/components/Spacing';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { buildCentralSubCategories } from '@/pages/notice/const';
 import { Category } from '@/components/Category';
 import { useSearchNoticePosts } from '@/pages/notice/queries';
@@ -21,7 +21,6 @@ const breakpointPosts: Record<string, number> = {
 
 const NoticeSection = () => {
   const breakpoint = useBreakpoints();
-  useEffect(() => console.log(breakpoint), [breakpoint]);
   const [subCategory, setSubCategory] = useState<string>('전체');
   const { t } = useTranslation();
   const centralSubCategories = useMemo(() => buildCentralSubCategories(t), [t]);

--- a/src/pages/notice/edit/component/ImageDropzone.tsx
+++ b/src/pages/notice/edit/component/ImageDropzone.tsx
@@ -60,6 +60,7 @@ export function ImageDropzone({ onDrop }: ImageDropzoneProps) {
       'image/webp': ['.webp'],
     },
     multiple: true,
+    disabled: isCompressing,
   });
 
   return (

--- a/src/pages/notice/edit/container/noticeEditImageSection.tsx
+++ b/src/pages/notice/edit/container/noticeEditImageSection.tsx
@@ -1,7 +1,9 @@
 import { ImageDropzone } from '../component/ImageDropzone';
 import { ImagePreview } from '../component/ImagePreview';
 import { useImageManager } from '../hook/useImageManager';
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback } from 'react';
+import { useAtom } from 'jotai';
+import { compressErrorState } from '@/pages/notice/state';
 
 interface NoticeEditImageSectionProps {
   onImagesChange: (images: File[]) => void;
@@ -9,7 +11,7 @@ interface NoticeEditImageSectionProps {
 
 export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectionProps): JSX.Element {
   const { images, addImage, removeImage, getValidImages } = useImageManager();
-  const [compressError, setCompressError] = useState<boolean>(false);
+  const [compressError, setCompressError] = useAtom(compressErrorState);
 
   useEffect(() => {
     if (compressError) {
@@ -18,7 +20,7 @@ export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectio
       }, 3000);
       return () => clearTimeout(timer);
     }
-  }, [compressError]);
+  }, [compressError, setCompressError]);
 
   useEffect(() => {
     onImagesChange(getValidImages());
@@ -34,7 +36,7 @@ export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectio
   return (
     <div className="px-[30px] xl:px-[200px]">
       <div className="mt-[12px] flex h-[270px] w-full flex-row items-center justify-start gap-4 overflow-x-auto whitespace-nowrap rounded-xs border-[0.125rem] border-gray-300 p-4">
-        <ImageDropzone onDrop={handleImageAdd} onCompressError={() => setCompressError(true)} />
+        <ImageDropzone onDrop={handleImageAdd} />
         <div className="flex max-w-full flex-row gap-4">
           {images.map((imageItem, index) => (
             <ImagePreview

--- a/src/pages/notice/edit/container/noticeEditImageSection.tsx
+++ b/src/pages/notice/edit/container/noticeEditImageSection.tsx
@@ -9,16 +9,16 @@ interface NoticeEditImageSectionProps {
 
 export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectionProps): JSX.Element {
   const { images, addImage, removeImage, getValidImages } = useImageManager();
-  const [sizeError, setSizeError] = useState<boolean>(false);
+  const [compressError, setCompressError] = useState<boolean>(false);
 
   useEffect(() => {
-    if (sizeError) {
+    if (compressError) {
       const timer = setTimeout(() => {
-        setSizeError(false);
+        setCompressError(false);
       }, 3000);
       return () => clearTimeout(timer);
     }
-  }, [sizeError]);
+  }, [compressError]);
 
   useEffect(() => {
     onImagesChange(getValidImages());
@@ -34,7 +34,7 @@ export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectio
   return (
     <div className="px-[30px] xl:px-[200px]">
       <div className="mt-[12px] flex h-[270px] w-full flex-row items-center justify-start gap-4 overflow-x-auto whitespace-nowrap rounded-xs border-[0.125rem] border-gray-300 p-4">
-        <ImageDropzone onDrop={handleImageAdd} onFileSizeError={() => setSizeError(true)} />
+        <ImageDropzone onDrop={handleImageAdd} onCompressError={() => setCompressError(true)} />
         <div className="flex max-w-full flex-row gap-4">
           {images.map((imageItem, index) => (
             <ImagePreview
@@ -46,9 +46,7 @@ export function NoticeEditImageSection({ onImagesChange }: NoticeEditImageSectio
           ))}
         </div>
       </div>
-      {sizeError && (
-        <p className="my-1 ml-1 font-medium text-red-500">10MB를 초과하는 이미지는 업로드할 수 없습니다.</p>
-      )}
+      {compressError && <p className="my-1 ml-1 font-medium text-red-500">이미지 최적화 중 에러가 발생했습니다.</p>}
     </div>
   );
 }

--- a/src/pages/notice/edit/container/noticeEditSubmitButton.tsx
+++ b/src/pages/notice/edit/container/noticeEditSubmitButton.tsx
@@ -1,4 +1,6 @@
 import { RegisterButton } from '@/components/deprecated/Buttons/BoardActionButtons';
+import { compressLoadingState } from '@/pages/notice/state';
+import { useAtomValue } from 'jotai';
 
 interface NoticeEditSubmitButtonProps {
   onSubmit: () => void;
@@ -6,9 +8,14 @@ interface NoticeEditSubmitButtonProps {
 }
 
 export function NoticeEditSubmitButton({ onSubmit, isLoading }: NoticeEditSubmitButtonProps) {
+  const isCompressing = useAtomValue(compressLoadingState);
   return (
     <div className="flex items-end justify-end px-[30px] pb-[320px] pt-[32px] lg:pb-[160px] xl:px-[200px]">
-      <RegisterButton className="h-[36px] w-full md:w-[80px]" onClick={onSubmit} disabled={isLoading} />
+      <RegisterButton
+        className="h-[36px] w-full md:w-[80px]"
+        onClick={onSubmit}
+        disabled={isLoading || isCompressing}
+      />
     </div>
   );
 }

--- a/src/pages/notice/state.ts
+++ b/src/pages/notice/state.ts
@@ -1,0 +1,5 @@
+import { atom } from 'jotai';
+
+// 이미지 압축 상태를 나타내는 atom state입니다.
+export const compressLoadingState = atom(false);
+export const compressErrorState = atom(false);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2825,6 +2825,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browser-image-compression@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "browser-image-compression@npm:2.0.2"
+  dependencies:
+    uzip: "npm:0.20201231.0"
+  checksum: 10c0/32be07f8849f2de501a71f6dd07e691c085fc7a2055456eb120fe5d765e3fcf7de00696915a8d614527d4df10f34c31526304b7d18aae036bb1c58d801e3fcbd
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.24.0, browserslist@npm:^4.24.4":
   version: 4.24.4
   resolution: "browserslist@npm:4.24.4"
@@ -4003,6 +4012,7 @@ __metadata:
     "@vitejs/plugin-react": "npm:^4.3.4"
     autoprefixer: "npm:^10.4.21"
     axios: "npm:^1.8.4"
+    browser-image-compression: "npm:^2.0.2"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
     date-fns: "npm:^3.6.0"
@@ -6175,6 +6185,13 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942
+  languageName: node
+  linkType: hard
+
+"uzip@npm:0.20201231.0":
+  version: 0.20201231.0
+  resolution: "uzip@npm:0.20201231.0"
+  checksum: 10c0/44b261b20ac7e4d71e7099d7a7c4885626044be61cd246e76cf548fa444a4a37c301d1a683679168bc29c91d2ec81d62b8c1c75217a26b37f6ce35223866c2d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #568

공지사항 게시판 이미지 input에 적용해줬습니다. 
이미지 압축 함수입니다. 1MB 이하로 압축하고, 최대 너비 또는 높이를 1080px로 설정합니다. 형식은 WebP로 변환합니다.
```
  const compressImages = async (files: File[]) => {
    setCompressing(true);
    setCompressError(false);

    const compressedFiles: File[] = [];

    for (const file of files) {
      try {
        const compressedBlob = await imageCompression(file, {
          maxSizeMB: 1,
          maxWidthOrHeight: 1080,
          useWebWorker: true,
          fileType: 'image/webp',
        });

        const baseName = file.name.replace(/\.[^/.]+$/, '');
        const webpName = `${baseName}.webp`;

        const finalFile = new File([compressedBlob], webpName, {
          type: compressedBlob.type || file.type,
          lastModified: Date.now(),
        });

        compressedFiles.push(finalFile);
      } catch (_error) {
        setCompressError(true);
      }
    }

    setCompressing(false);
    return compressedFiles;
  };

```

압축 상태는 state.ts의 
```
export const compressLoadingState = atom(false);
export const compressErrorState = atom(false);
```
으로 관리합니다. - 압축 도중 ImageDropZone에 스피너 활성화, SubmitButton disabled

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
