### PR TITLE
refactor: Edit 페이지 일반화

### DIFF
--- a/src/components/EditEditorSection.tsx
+++ b/src/components/EditEditorSection.tsx
@@ -1,0 +1,165 @@
+import { ReactNode } from 'react';
+import { Editor } from '@toast-ui/react-editor';
+
+import { useEditContext } from '@/containers/edit/useEditContext';
+
+import { cn } from '@/libs/utils';
+import { Input } from '@/components/ui/input';
+
+interface EditEditorSectionRootProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * 게시글 작성/수정 화면에서 사용하는 에디터 section 컴포넌트입니다.
+ *
+ * 사용예시를 보면 알 수 있듯이 필요한 컴포넌트를 선택적으로 사용하면 됩니다.
+ *
+ * @example 사용 예시
+ * ```tsx
+ * <EditEditorSection>
+ *  <EditEditorSection.Title essential>피해 사실 기술</EditEditorSection.Title>
+ *
+ *  <EditEditorSection.InputArea>
+ *    <EditEditorSection.Input
+ *      placeholder="제목을 입력하세요."
+ *    />
+ *    <EditEditorSection.SideSlot position="right">
+ *      <FilterDropDown
+ *        className="flex h-[44px] w-full items-center justify-center border-gray-500 py-0 text-[19px] font-medium"
+ *        defaultValue="카테고리"
+ *        optionValue={categories}
+ *        onValueChange={(value) => {
+ *          setCategory(value);
+ *          setValue('category', value);
+ *        }}
+ *        value={category}
+ *      />
+ *    </EditEditorSection.SideSlot>
+ *  </EditEditorSection.InputArea>
+ *
+ *  <EditEditorSection.Editor />
+ * </EditEditorSection>
+ * ```
+ */
+function EditEditorSectionRoot({ children, className = '' }: EditEditorSectionRootProps) {
+  return <section className={cn('mb-16 flex flex-col gap-6', className)}>{children}</section>;
+}
+
+function EditEditorSectionTitle({ children, essential = false }: { children: ReactNode; essential?: boolean }) {
+  return (
+    <h2
+      className={cn(
+        'text-2xl font-semibold',
+        essential && 'before:absolute before:-translate-x-full before:text-[#ff0000] before:content-["*"]'
+      )}
+    >
+      {children}
+    </h2>
+  );
+}
+
+function EditEditorSectionInputArea({
+  children,
+  validityArea = false,
+}: {
+  children: ReactNode;
+  validityArea?: boolean;
+}) {
+  return <div className={cn(validityArea && 'flex flex-col gap-[10px] md:flex-row')}>{children}</div>;
+}
+
+function EditEditorSectionInput({
+  placeholder = '제목을 입력하세요.',
+  className = '',
+}: {
+  placeholder?: string;
+  className?: string;
+}) {
+  const { form } = useEditContext();
+  const {
+    register,
+    formState: { errors },
+  } = form;
+
+  const titleError = errors?.title;
+
+  return (
+    <div className="w-full">
+      <Input id="title" type="text" placeholder={placeholder} className={cn(className)} {...register('title')} />
+      <p
+        className={cn(
+          'mt-1 text-sm text-red-700 transition-all',
+          titleError ? 'h-5 translate-y-0 opacity-100' : 'h-0 -translate-y-2 opacity-0'
+        )}
+      >
+        {titleError && titleError.type === 'too_big' ? '제목은 50자 이내이여야 합니다.' : '이 값은 필수입니다.'}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * PC 해상도에서는 Input의 왼쪽 혹은 오른쪽,
+ * 모바일 해상도에서는 Input의 위 혹은 아래에 위치하는 컴포넌트입니다.
+ *
+ * @example 사용 예시
+ * ```tsx
+ * <EditEditorSection.InputArea>
+ *   <EditEditorSection.Input
+ *     placeholder="제목을 입력하세요."
+ *     {...register('title')}
+ *   />
+ *     <EditEditorSection.SubSlot position="right">
+ *     <FilterDropDown
+ *       className="flex h-[44px] w-full items-center justify-center border-gray-500 py-0 text-[19px] font-medium"
+ *       defaultValue="카테고리"
+ *       optionValue={categories}
+ *       onValueChange={(value) => {
+ *         setCategory(value);
+ *         setValue('category', value);
+ *       }}
+ *       value={category}
+ *     />
+ *   </EditEditorSection.SubSlot>
+ * </EditEditorSection.InputArea>
+ * ```
+ */
+function EditEditorSectionSubSlot({
+  children,
+  position = 'right_down',
+}: {
+  children: ReactNode;
+  position?: 'left_top' | 'right_down';
+}) {
+  return (
+    <div className={cn('flex-shrink-0', 'w-full', position === 'left_top' ? 'md:order-first' : 'md:order-last')}>
+      {children}
+    </div>
+  );
+}
+
+function EditEditorSectionEditor() {
+  const { handleContentChange, handleContentBlur, register: registerEditor } = useEditContext();
+
+  return (
+    <Editor
+      height="620px"
+      initialValue=""
+      placeholder="글을 작성해주세요"
+      useCommandShortcut={true}
+      onChange={handleContentChange}
+      onBlur={handleContentBlur}
+      {...registerEditor}
+    />
+  );
+}
+
+export const EditEditorSection = Object.assign(EditEditorSectionRoot, {
+  Title: EditEditorSectionTitle,
+  InputArea: EditEditorSectionInputArea,
+  Input: EditEditorSectionInput,
+  SubSlot: EditEditorSectionSubSlot,
+  Editor: EditEditorSectionEditor,
+});

--- a/src/components/EditFileUploader.tsx
+++ b/src/components/EditFileUploader.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/libs/utils';
+
+import { FileInputs, FileInputsProps } from '@/components/edit/FileInputs';
+import { useEditContext } from '@/containers/edit/useEditContext';
+
+interface EditFileUploaderRootProps {
+  children: ReactNode;
+  className?: string;
+}
+
+function EditFileUploaderRoot({ children, className = '' }: EditFileUploaderRootProps) {
+  return <section className={cn('mb-16', className)}>{children}</section>;
+}
+
+function EditFileUploaderTitle({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return <h2 className={cn('mb-6 text-2xl font-semibold', className)}>{children}</h2>;
+}
+
+function EditFileUploaderFileInputs({
+  sizeLimit,
+  categories,
+}: {
+  sizeLimit: FileInputsProps['sizeLimit'];
+  categories?: FileInputsProps['categories'];
+}) {
+  const { files, handleFilesChange } = useEditContext();
+
+  return (
+    <FileInputs
+      categories={categories ? categories : undefined}
+      files={files}
+      onChange={handleFilesChange}
+      sizeLimit={sizeLimit}
+    />
+  );
+}
+
+export const EditFileUploader = Object.assign(EditFileUploaderRoot, {
+  Tilte: EditFileUploaderTitle,
+  FileInputs: EditFileUploaderFileInputs,
+});

--- a/src/components/EditFooter.tsx
+++ b/src/components/EditFooter.tsx
@@ -1,0 +1,33 @@
+import { ArticleFooter } from '@/containers/new/ArticleFooter';
+import { cn } from '@/libs/utils';
+import { Button } from '@/components/ui/button';
+import { useEditContext } from '@/containers/edit/useEditContext';
+import { Loader2 } from 'lucide-react';
+import { ReactNode } from 'react';
+
+interface EditFooterProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function EditFooter({ children, className }: EditFooterProps) {
+  const { form, submitForm, isImageProcessing, isFileUploadPending } = useEditContext();
+  const { formState, handleSubmit } = form;
+  const { errors } = formState;
+
+  return (
+    <ArticleFooter className={cn('pb-6', className)}>
+      <Button
+        variant="register"
+        className="flex items-center justify-center gap-1 self-end px-2"
+        disabled={Object.keys(errors).length > 0 || isImageProcessing || isFileUploadPending}
+        onClick={handleSubmit(submitForm)}
+      >
+        <Loader2
+          className={cn('animate-spin transition-all', isImageProcessing ? 'ml-0 opacity-100' : '-ml-7 opacity-0')}
+        />
+        <p>{children}</p>
+      </Button>
+    </ArticleFooter>
+  );
+}

--- a/src/components/edit/FileInputs.tsx
+++ b/src/components/edit/FileInputs.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent, useEffect, useState } from 'react';
 import { FileInput, PostFile } from '@/components/edit/FileInput';
 import { cn } from '@/libs/utils.ts';
 
-interface FileInputsProps {
+export interface FileInputsProps {
   className?: string;
   sizeLimit?: number;
   files?: PostFile[];

--- a/src/containers/edit/index.tsx
+++ b/src/containers/edit/index.tsx
@@ -1,0 +1,92 @@
+import type { UseFormReturn } from 'react-hook-form';
+
+import { Container } from '@/containers/new/Container';
+import { PostHeader } from '@/components/detail/PostHeader';
+import { PostFooter } from '@/components/detail/PostFooter';
+
+import { cn } from '@/libs/utils';
+import { EditContext, EditContextType } from './useEditContext';
+import { UseContentEditorReturn } from '@/hooks/useContentEditor';
+import { PostFile } from '@/components/edit/FileInput';
+
+interface EditProviderProps<T extends Record<string, unknown>> {
+  postId: string;
+
+  form: UseFormReturn<T>;
+
+  register: UseContentEditorReturn['register'];
+  isImageProcessing: UseContentEditorReturn['isImageProcessing'];
+  processImages: UseContentEditorReturn['processImages'];
+
+  files: PostFile[];
+  isFileUploadPending: boolean;
+  handleFilesChange(newFiles: PostFile[]): void;
+  handleContentChange(): void;
+  handleContentBlur(): void;
+
+  submitForm(formData: T): Promise<void>;
+
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function EditPage<T extends Record<string, unknown>>({
+  postId,
+  form,
+
+  register,
+  isImageProcessing,
+  processImages,
+
+  files,
+  isFileUploadPending,
+  handleFilesChange,
+  handleContentChange,
+  handleContentBlur,
+
+  submitForm,
+
+  children,
+  className,
+}: EditProviderProps<T>) {
+  const contextValue = {
+    id: postId,
+    form,
+    register,
+    isImageProcessing,
+    processImages,
+    files,
+    isFileUploadPending,
+    handleFilesChange,
+    handleContentChange,
+    handleContentBlur,
+    submitForm,
+  };
+
+  return (
+    <EditContext.Provider value={contextValue as unknown as EditContextType<Record<string, unknown>>}>
+      <article className={cn('mt-[200px]', className)}>{children}</article>
+    </EditContext.Provider>
+  );
+}
+
+///// PageSkeleton /////
+EditPage.PageSkeleton = function EditPageSkeleton() {
+  return (
+    <article className="mb-20 mt-16">
+      <PostHeader.Skeleton />
+      <hr className="bg-[#E7E7E7]" />
+      <Container.Skeleton />
+      <PostFooter.Skeleton />
+    </article>
+  );
+};
+
+///// ErrorPage /////
+EditPage.ErrorPage = function EditErrorPage() {
+  return (
+    <div className="mt-16 flex items-center justify-center py-12">
+      <p>오류가 발생하였습니다. 해당 페이지의 캡처본과 함께 관리자에게 문의하십시오.</p>
+    </div>
+  );
+};

--- a/src/containers/edit/useEditContext.ts
+++ b/src/containers/edit/useEditContext.ts
@@ -1,0 +1,30 @@
+import { PostFile } from '@/components/edit/FileInput';
+import { UseContentEditorReturn } from '@/hooks/useContentEditor';
+import { createContext, useContext } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+
+export interface EditContextType<T extends Record<string, unknown>> {
+  id: number | null;
+
+  form: UseFormReturn<T>;
+
+  register: UseContentEditorReturn['register'];
+  isImageProcessing: UseContentEditorReturn['isImageProcessing'];
+  processImages: UseContentEditorReturn['processImages'];
+
+  files: PostFile[];
+  isFileUploadPending: boolean;
+  handleFilesChange(newFiles: PostFile[]): void;
+  handleContentChange(): void;
+  handleContentBlur(): void;
+
+  submitForm(formData: T): Promise<void>;
+}
+
+export const EditContext = createContext<EditContextType<Record<string, unknown>> | null>(null);
+
+export function useEditContext<T extends Record<string, unknown>>() {
+  const context = useContext(EditContext) as EditContextType<T> | null;
+  if (!context) throw Error('Edit Slot 컴포넌트는 EditProvider 내부에서 사용해야 합니다.');
+  return context;
+}

--- a/src/hooks/useContentEditor.ts
+++ b/src/hooks/useContentEditor.ts
@@ -6,7 +6,7 @@ import { PostFileResponse, UploadFilesResponse } from '@/hooks/new/mutations/use
 import { ApiResponse } from '@/hooks/new/useStuQuery.ts';
 import { FileResponse } from '@/schemas/post';
 
-interface UseContentEditorReturn {
+export interface UseContentEditorReturn {
   register: {
     hooks: HookMap;
     ref: RefObject<Editor>;

--- a/src/pages/human-rights/edit/page.tsx
+++ b/src/pages/human-rights/edit/page.tsx
@@ -255,12 +255,14 @@ export function HumanRightsEditPage() {
     const postFileList: number[] = files
       .filter((file): file is UploadedPostFile => file.isUploaded)
       .map(({ id }) => id);
+
     if (files) {
       const localFiles = files.filter((file): file is LocalPostFile => !file.isUploaded).map(({ file }) => file);
       const uploaded = await uploadFiles({ files: localFiles });
       uploaded.postFiles.forEach(({ id }) => postFileList.push(id));
     }
     const uploadedImages: FileResponse[] = post?.postFileList?.filter(({ fileType }) => fileType === 'images') ?? [];
+
     const { existedImages, newImages, content } = await processImages(uploadedImages);
     existedImages.forEach(({ postFileId }) => postFileList.push(postFileId));
     newImages.forEach(({ id }) => postFileList.push(id));


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #585 

---

- 각 Edit 페이지가 공통적으로 가지고 있는
  - Editor Section
  - FileInputs Section
  - Footer
- 를 UI 측면에서 일반화 했습니다.

<br />

- 하지만 공통 로직을 일반화하는 과정에서 깊은 고민이 들어 이렇게 PR을 올립니다. 우선 제가 생각하는 방향으로 해당 PR 이후 바로 이어서 작업하고자 합니다.
- 우선 현재 일반화 한 방향성이 맞는지 봐주시면 감사하겠습니다.

<br />

- 그리고 각 get 함수와 mutation 함수도 내부로 다룰 수 있도록 하고 싶은데,
- 각 페이지별로 지니고 있는 타입이 다르고, 이미 useGetPost을 통해 타입과 zod 스키마로 결합되어 있어 페이지별로 데이터를 가져오거나 mutate 하는 훅의 타입이 모두 달라 일반화 하기 어려움을 겪고 있습니다.
- 그래서
 
```tsx
import { useGetPost } from '@/hooks/useGetPost';
import { ZodSchema } from 'zod';
// … 생략 …

interface EditPageProps<TForm, TRaw, TData> {
  boardCode: string;
  postId: string;
  form: UseFormReturn<TForm>;
  zodSchema?: ZodSchema<TData, any, TRaw>;
  children: React.ReactNode;
  className?: string;
}

export function EditPage<TForm, TRaw, TData = TRaw>({
  boardCode,
  postId,
  form,
  zodSchema,
  children,
  className,
}: EditPageProps<TForm, TRaw, TData>) {
  const id = postId ? parseInt(postId) : null;
  const mode = id ? 'edit' : 'create';

  // 1) 페칭 훅 내부 호출
  const {
    data: rawResponse,
    isLoading,
    isError,
    error,
  } = useGetPost<TRaw, TData>({
    boardCode,
    postId: id!,
    zodSchema,
    queryOptions: { enabled: !!id },
  });

  // 2) 스켈레톤 · 에러 처리
  if (isLoading) return <EditPage.PageSkeleton />;
  if (isError || !rawResponse) {
    const messages = error instanceof Error ? [error.message] : [];
    return <EditPage.ErrorPage errorMessage={messages} />;
  }

  // 3) postTransformer 호출 (Slot에서 사용하도록 context에 포함)
  const postData = rawResponse;

  // 4) 에디터 훅, 파일 훅, submitForm 등 기존 로직 그대로
  const editorRef = useRef<Editor>(null);
  const { register, isImageProcessing, processImages } = useContentEditor(boardCode, editorRef);
  const [files, setFiles] = useState<PostFile[]>([]);
  // … 유효성 검사, submitForm 구현 …

  const contextValue: EditContextType<TForm> = {
    id,
    mode,
    form,
    register,
    isImageProcessing,
    processImages,
    isFileUploadPending: false, // 파일 훅 상태
    handleContentChange,
    handleContentBlur,
    submitForm,
    // post 데이터도 필요하면 추가
    postData,
  };

  return (
    <EditContext.Provider value={contextValue}>
      <article className={cn('mt-[200px]', className)}>{children}</article>
    </EditContext.Provider>
  );
}

```
- 이런식으로 아예 일반화 한 컴포넌트에서 useGetPost와 같이 공통적으로 사용하는 훅을 가지고 있고, zod 스키마를 받아서 적용하는 방식을 생각해봤는데, 기존 코드 구조를 완전히 변경하는 방식이어서 너무 과한 것이 아닌가라는 생각이 듭니다.
- 위에서 언습했듯이 지금의 방향성이 맞는지와 어떻게 해야 효과적으로 로직을 일반화할 수 있을지 의견 주시면 정말 감사하겠습니다.
- 그리고 이렇게 작업이 지연되게 하여 너무 송구스럽고 죄송합니다. 앞으로 절대 이런일 없도록 하겠습니다..ㅠ

## 2️⃣ 추후 작업할 내용

- 현재 작업은 UI 측면에서 일반화 한 상태이기에 각 공통 로직을 내포할 수 있도록 리팩토링 해야합니다.
- 로직 일반화 즉 공통 로직은 EditPage 내부에서 처리할 수 있도록 변경한 후,
- data, huma-right, qna, service 이렇게 순차적으로 일반화한 EditPage를 이용해 리팩토링을 진행할 예정입니다.

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
