### PR TITLE
hotfix: 서비스 공지사항 페이지 이슈

### DIFF
--- a/src/pages/mypage/service-notice/[id]/container/serviceNoticeDetailEditSection.tsx
+++ b/src/pages/mypage/service-notice/[id]/container/serviceNoticeDetailEditSection.tsx
@@ -31,7 +31,7 @@ export function ServiceNoticeDetailEditSection({
   const handleDelete = async () => {
     await delBoardPosts(boardCode, postId, fileurl);
     queryClient.invalidateQueries({
-      queryKey: ['get-board-boardCode-posts', boardCode],
+      queryKey: ['searchPosts', boardCode],
     });
     navigate(`/service-notice`);
   };

--- a/src/pages/mypage/service-notice/component/ServiceNoticePostContent.tsx
+++ b/src/pages/mypage/service-notice/component/ServiceNoticePostContent.tsx
@@ -28,10 +28,7 @@ export function ServiceNoticePostContent({
       : ''; // Default style
 
   return (
-    <Link
-      {...props}
-      className={cn('flex h-[64px] border-b-[1px] border-[#9CA3AF]', className)}
-    >
+    <Link {...props} className={cn('flex h-[64px] border-b-[1px] border-[#9CA3AF]', className)}>
       {Emergency ? (
         <Badge variant="emergency-old" className="relative top-[22px] text-[12px]">
           긴급

--- a/src/pages/mypage/service-notice/component/ServiceNoticePostContent.tsx
+++ b/src/pages/mypage/service-notice/component/ServiceNoticePostContent.tsx
@@ -31,7 +31,6 @@ export function ServiceNoticePostContent({
     <Link
       {...props}
       className={cn('flex h-[64px] border-b-[1px] border-[#9CA3AF]', className)}
-      style={{ width: `${contentWidth}px` }}
     >
       {Emergency ? (
         <Badge variant="emergency-old" className="relative top-[22px] text-[12px]">

--- a/src/pages/mypage/service-notice/page.tsx
+++ b/src/pages/mypage/service-notice/page.tsx
@@ -66,7 +66,7 @@ export function ServiceNoticePage() {
         </div>
         <div className="flex justify-end">
           {writable && (
-            <Link className={cn(buttonVariants({ variant: 'outline' }), 'gap-2')} to="/data/edit">
+            <Link className={cn(buttonVariants({ variant: 'outline' }), 'gap-2')} to="/service-notice/edit">
               <Pencil className="size-4" />
               <p>글쓰기</p>
             </Link>

--- a/src/pages/notice/edit/hook/useNoticeEdit.ts
+++ b/src/pages/notice/edit/hook/useNoticeEdit.ts
@@ -131,7 +131,7 @@ export function useNoticeEdit() {
       const postId = createPostResponse?.data.post_id;
 
       queryClient.invalidateQueries({
-        queryKey: ['get-board-boardCode-posts', SERVICE_NOTICE_BOARD_CODE],
+        queryKey: ['searchPosts', SERVICE_NOTICE_BOARD_CODE],
       });
 
       navigate(`/service-notice/${postId}`);


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #640

원인
- 카드 뷰의 너비 기준이 페이지 너비였음
- 글쓰기 버튼 클릭 시 /data/edit으로 가게 돼있었음

## 2️⃣ 추후 작업할 내용

## 3️⃣ 체크리스트

- [ ] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
