### PR TITLE
fix: 공지사항 페이지네이션 이동 시 태그 파라미터 유실 버그 수정

### DIFF
--- a/src/hooks/useQueryUpdater.ts
+++ b/src/hooks/useQueryUpdater.ts
@@ -1,9 +1,15 @@
-import { useMemo } from 'react';
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router';
 
 export const useQueryUpdater = (): ((query: string, value: string | ((prevValue: string) => string)) => string) => {
-  const search = useMemo(() => new URLSearchParams(location.search), []);
-  return (query, value) => {
-    search.set(query, typeof value === 'string' ? value : value(search.get(query) ?? ''));
-    return `?${search.toString()}`;
-  };
+  const [searchParams] = useSearchParams();
+
+  return useCallback(
+    (query, value) => {
+      const newParams = new URLSearchParams(searchParams.toString());
+      newParams.set(query, typeof value === 'string' ? value : value(newParams.get(query) ?? ''));
+      return `?${newParams.toString()}`;
+    },
+    [searchParams]
+  );
 };


### PR DESCRIPTION
## 1️⃣ 작업 내용 Summary

- resolved #643
- 페이지네이션 이동 시 파라미터(태그 등)가 유실되는 버그 수정
- `useQueryUpdater`에서 `location.search`를 캐싱하지 않고, `react-router`의 `useSearchParams`를 사용해 최신 쿼리 상태를 반영하도록 변경

## 2️⃣ 추후 작업할 내용

- 없음

## 3️⃣ 체크리스트

- [x] `develop` 브랜치의 최신 코드를 `pull` 받았나요?
